### PR TITLE
Fix error on logging when hints are made

### DIFF
--- a/hanabi_classes.py
+++ b/hanabi_classes.py
@@ -99,6 +99,7 @@ class Round:
         """Retrieve and execute AI p's play for whoever's turn it is."""
         play = playType, playValue = p.play(self)
         self.playHistory.append(play)
+        hand = self.h[self.whoseTurn]
 
         if playType == 'hint':
             assert self.hints != 0
@@ -114,7 +115,6 @@ class Round:
 
         else:
             card = playValue
-            hand = self.h[self.whoseTurn]
             assert card in hand.cards
 
             description = card['name']


### PR DESCRIPTION
When a player gives a hint, the hand variable is not defined when reaching line 142 with the verbose option.
