### PR TITLE
Add a Basic Hanabi Player

### DIFF
--- a/hanabi_wrapper.py
+++ b/hanabi_wrapper.py
@@ -13,6 +13,7 @@ import sys
 from scipy import stats, mean
 from play_hanabi import play_one_round
 from cheating_idiot_player import CheatingIdiotPlayer
+from most_basic_player import MostBasicPlayer
 ### TODO: IMPORT YOUR PLAYER HERE
 
 def usage():
@@ -37,6 +38,8 @@ players = []
 for i in range(len(rawNames)):
     if rawNames[i] == 'cheater':
         players.append(CheatingIdiotPlayer())
+    elif rawNames[i] == 'basic':
+        players.append(MostBasicPlayer())
     ### TODO: YOUR NEW PLAYER NAME GOES HERE
     # elif rawNames[i] == 'yourDumbName':
     #     players.append(YourDumbPlayer())

--- a/most_basic_player.py
+++ b/most_basic_player.py
@@ -1,0 +1,59 @@
+"""A Most Basic Hanabi player
+
+Most Basic Players only play if they know for certain that a card is
+playable.  Otherwise, if there are hints available and another player
+has a playable card, Basic will give a random hint about that card.
+Otherwise, they discard randomly.
+Basic players can only handle rainbow as an ordinary 6th suit.
+"""
+
+from hanabi_classes import *
+
+class MostBasicPlayer:
+    def get_my_playable(self, cards, progress):
+        playableCards = []
+        for card in cards:
+            suit = ''
+            value = ''
+            for info in card['direct']: # Basic players only use direct info
+                if info in 'rygbw?':  #TODO: use constants
+                    suit = info
+                elif info in '12345':
+                    value = info
+                #else something was invalid
+            if suit != '' and value != '' and progress[suit] == int(value) - 1:
+                playableCards.append(card)
+        return playableCards
+
+    def get_playable(self, cards, progress):
+        playableCards = []
+        for card in cards:
+            value, suit = card['name']
+            if progress[suit] == int(value) - 1:
+                playableCards.append(card)
+        return playableCards
+
+    def play(self, r):
+        # check my knowledge about my cards, are any playable?
+        cards = r.h[r.whoseTurn].cards # don't look!
+        progress = r.progress
+        myPlayableCards = self.get_my_playable(cards, progress)
+
+        if myPlayableCards != []:
+            return 'play', random.choice(myPlayableCards)
+
+        if r.hints > 0:
+            # look around at each other hand to see if anything is playable
+            for i in range(0, r.nPlayers):
+                if i == r.whoseTurn:
+                    continue # don't look at your own hand
+                othersCards = r.h[i].cards
+                playableCards = self.get_playable(othersCards, progress)
+
+                if playableCards != []:
+                    # hint a random attribute about a random card in that hand
+                    hintTarget = random.choice(playableCards)
+                    return 'hint', (i, random.choice(hintTarget['name']))
+
+        # alright, don't know what to do, let's toss
+        return 'discard', random.choice(cards)


### PR DESCRIPTION
Add a basic, non-cheating, Hanabi player.  Basic players can play cards
for which they know the number and color, and they give hints about
playable cards, but without considering what the other player already
knows, or what other cards that hint covers.  Otherwise they discard at
random.  Basic players would be confused by multicolored cards.
