### PR TITLE
Full implementation of logging to file

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
       pi (AI for player i): cheater, basic, brainbow, or newest
       game_type: rainbow, purple, or vanilla
       n_rounds: positive int
-      verbosity: silent, scores, or verbose
+      verbosity: silent, scores, verbose, or log
 
 There is no max number of players.  With more than 5, the hand size is still 4
 cards.

--- a/README.md
+++ b/README.md
@@ -22,20 +22,24 @@ or
 or
 
     ROUND 1:
-    [HANDS] Cheater1: 3g 4w 2r 1y
-            Cheater2: 3r 2b 3w 3y
-            Cheater3: 3b 1b 1r 3?
-            Cheater4: 2b 5w 4b 1r
-    [PLAYS] Cheater1 plays 1y
-            Cheater2 discards 2b
-            Cheater3 plays 1b
-            Cheater4 plays 1r
+    [HANDS] Cheater1: 3y 1? 3w 3r
+            Cheater2: 2g 3w 3g 1r
+            Cheater3: 2? 4? 1y 2b
+            Cheater4: 1b 2r 1b 1w
+    [PLAYS] Cheater1 [3y 1? 3w 3r] plays 1? and draws 1w
+            Cheater2 [2g 3w 3g 1r] plays 1r and draws 1y
+            Cheater3 [2? 4? 1y 2b] plays 2? and draws 3y
+            Cheater4 [1b 2r 1b 1w] plays 1w and draws 3g
             ...
-            Cheater1 discards 3r
-            Cheater2 discards 1?
-            Cheater3 discards 2?
-            Cheater4 plays 5r
-    Score: 28 
+            Cheater1 [3y 1r 2w 3?] plays 3y and draws 5y
+            Cheater2 [1g 1? 1b 2b] discards 1? and draws 2?
+            Cheater3 [1y 3y 3r 4b] discards 3y and draws 2y
+            Cheater4 [1y 1g 2r 5r] plays 5r
+            Cheater1 [1r 2w 3? 5y] discards 1r
+            Cheater2 [1g 1b 2b 2?] discards 1g
+            Cheater3 [1y 3r 4b 2y] discards 2y
+            Cheater4 [1y 1g 2r 3b] discards 2r
+    Score: 26
 
 ## Available players
 * **Cheating Idiot** (`cheater`) by RK  

--- a/hanabi_wrapper.py
+++ b/hanabi_wrapper.py
@@ -7,7 +7,8 @@ Command-line arguments (see usage):
     they're just another regular suit (effectively purple)
   n_rounds: Number of rounds to play
   verbosity: How much output to show ('silent', only final average scores;
-    'scores', result of each round; 'verbose', play by play)
+    'scores', result of each round; 'verbose', play by play; 'logging',
+    detailed log file for the gamestate at each play)
 """
 
 import sys, argparse
@@ -20,28 +21,30 @@ from basic_rainbow_player import BasicRainbowPlayer
 from newest_card_player import NewestCardPlayer
 ### TODO: IMPORT YOUR PLAYER
 
+# Define all available players
+availablePlayers = {'cheater'  : CheatingIdiotPlayer, ### TODO: ADD YOUR PLAYER
+                    'basic'    : MostBasicPlayer,
+                    'brainbow' : BasicRainbowPlayer,
+                    'newest'   : NewestCardPlayer}
+
 # Parse command-line args.
 parser = argparse.ArgumentParser(description='Process some integers.')
 parser.add_argument('requiredPlayers', metavar='p', type=str, nargs=2,
-                    help='cheater, basic, or brainbow')
+                    help=', '.join(availablePlayers.keys()))
 parser.add_argument('morePlayers', metavar='p', type=str, nargs='*')
 parser.add_argument('gameType', metavar='game_type', type=str,
                     help='rainbow, purple, or vanilla')
 parser.add_argument('nRounds', metavar='n_rounds', type=int,
                     help='positive int')
 parser.add_argument('verbosity', metavar='verbosity', type=str,
-                    help='silent, scores, or verbose')
+                    help='silent, scores, verbose, or logging')
 args = parser.parse_args()
 
 assert args.gameType in ('rainbow', 'purple', 'vanilla')
 assert args.nRounds > 0
-assert args.verbosity in ('silent', 'scores', 'verbose')
+assert args.verbosity in ('silent', 'scores', 'verbose', 'logging')
 
 # Load players.
-availablePlayers = {'cheater'  : CheatingIdiotPlayer, ### TODO: ADD YOUR PLAYER
-                    'basic'    : MostBasicPlayer,
-                    'brainbow' : BasicRainbowPlayer,
-                    'newest'   : NewestCardPlayer}
 players = []
 rawNames = args.requiredPlayers + args.morePlayers
 for i in range(len(rawNames)):
@@ -71,14 +74,15 @@ for i in range(len(names)):
 # Create logging object for all output
 logger = logging.getLogger('game_log')
 logger.setLevel(logging.DEBUG)
-ch = logging.StreamHandler() # TODO: enable file logging flag
+ch = logging.FileHandler('games.log') if args.verbosity == 'logging'\
+                                else logging.StreamHandler()
 ch.setLevel(logging.INFO)
 logger.addHandler(ch)
 
 # Play rounds.
 scores = []
 for i in range(args.nRounds):
-    if args.verbosity == 'verbose':
+    if args.verbosity == ('verbose' or 'logging'):
         logger.info('\n' + 'ROUND {}:'.format(i))
     score = play_one_round(args.gameType, players, names, args.verbosity)
     scores.append(score)


### PR DESCRIPTION
Added a new 'log' verbosity option, which will redirect all output to a games.log file. Additionally, this option will record all direct and indirect information every turn, to be used for analyzing AI decisions.

Also included in this commit: automatic addition of available AIs to argparse help, moved availablePlayers dictionary definition to the same area as class imports, and output format update in README.md. Reverted import of print_function from **future** for Python 2.x compatibility, since it isn't used anymore.
