### PR TITLE
Fix off by one error in card draw logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ or
             Cheater1 [3y 1r 2w 3?] plays 3y and draws 5y
             Cheater2 [1g 1? 1b 2b] discards 1? and draws 2?
             Cheater3 [1y 3y 3r 4b] discards 3y and draws 2y
-            Cheater4 [1y 1g 2r 5r] plays 5r
+            Cheater4 [1y 1g 2r 5r] plays 5r and draws 3b
             Cheater1 [1r 2w 3? 5y] discards 1r
             Cheater2 [1g 1b 2b 2?] discards 1g
             Cheater3 [1y 3r 4b 2y] discards 2y

--- a/hanabi_classes.py
+++ b/hanabi_classes.py
@@ -111,6 +111,8 @@ class Round:
         """Remove and return the top card of the deck."""
         return self.deck.pop(0)
 
+    # Discards card from hand, then attempts to draw a new card.
+    # Returns true if there was still a card to draw.
     def replace_card(self, card, hand):
         """Drop the card, draw a new one, and update public info."""
         if not card['known']:
@@ -118,6 +120,8 @@ class Round:
         hand.drop(card)
         if self.deck != []:
             hand.add(self.draw(), self.turnNumber)
+            return True
+        return False
 
     def printAllKnowledge(self):
         for i in range(self.nPlayers):
@@ -165,16 +169,14 @@ class Round:
             description = card['name']
 
             if playType == 'discard':
-                self.replace_card(card, hand)
-                self.hints = min(self.hints + 1, N_HINTS)
-                if self.deck != []:
+                if self.replace_card(card, hand):
                     description += ' and draws {}'\
                                     .format(hand.cards[-1]['name'])
+                self.hints = min(self.hints + 1, N_HINTS)
 
             elif playType == 'play':
                 value, suit = card['name']
-                self.replace_card(card, hand)
-                if self.deck != []:
+                if self.replace_card(card, hand):
                     description += ' and draws {}'\
                                     .format(hand.cards[-1]['name'])
                 if self.progress[suit] == int(value) - 1: # Legal play


### PR DESCRIPTION
The last card in the deck wasn't being logged when it was drawn, because the
deck was already empty once the logging was hit.  Instead the replace_card
method should report success if there was still a card to draw.
