### PR TITLE
Add hat player

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Python 3.
 
 ## Usage
     usage: ./hanabi_wrapper.py p1 p2 [p3 ...] [-t game_type] [-n n_rounds] [-v verbosity] [-l loss_score]
-      pi (AI for player i): idiot, cheater, basic, brainbow, newest, encoding, gencoding, or human
+      pi (AI for player i): idiot, cheater, basic, brainbow, newest, encoding, gencoding, hat, or human
       game_type: rainbow [default], purple, or vanilla
       n_rounds: positive int [default: 1]
       verbosity: verbose [default], scores, silent, or log
@@ -56,6 +56,8 @@ or
   Plays newest hinted card (and hints accordingly), discards oldest card
 * **Encoding** (`encoder`) & **General Encoding** (`gencoder`) by Taylor Robie<br>
   Experimental, hints counter-intuitively, Python 2 only (todo: 3!)
+* **Hat Player** (`hat`) by Floris van Doorn<br>
+  Uses "hat guessing" techniques to convey information to all other players with a single hint. Needs at least 4 players. Has about 80% win rate.
 * **Human** (`human`) by GH<br>
   Allows you to play alongside the AIs (works best on `-v silent` or `log`)
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ or
 ## Available players
 * **Cheating Idiot** (`idiot`) by RK<br>
   Peeks at own hand to know when to play, discards randomly, never hints
-* **Cheating** (`cheater`) by Floris van Doorn<br>
+* **Cheater** (`cheater`) by Floris van Doorn<br>
   Peeks at own hand to play, discard, and hint; high win rate
 * **Most Basic** (`basic`) by Ben Zax<br>
   Plays when certain, discards randomly, hints inefficiently, no rainbows

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Python 3.
 
 ## Usage
     usage: ./hanabi_wrapper.py p1 p2 [p3 ...] [-t game_type] [-n n_rounds] [-v verbosity] [-l loss_score]
-      pi (AI for player i): idiot, cheater, basic, brainbow, newest, encoding, gencoding, hat, or human
+      pi (AI for player i): idiot, cheater, basic, brainbow, newest, encoder, gencoder, hat, or human
       game_type: rainbow [default], purple, or vanilla
       n_rounds: positive int [default: 1]
       verbosity: verbose [default], scores, silent, or log

--- a/bot_utils.py
+++ b/bot_utils.py
@@ -7,12 +7,68 @@ from hanabi_classes import *
 
 def get_plays(cards, progress):
     """Return a list of plays (subset of input); call only on visible cards!"""
-    plays = []
-    for card in cards:
-        value, suit = card['name']
-        if progress[suit] == int(value) - 1:
-            plays.append(card)
-    return plays
+    return list(filter\
+            (lambda x: int (x['name'][0]) == progress[x['name'][1]] + 1, cards))
+
+def get_played_cards(cards, progress):
+    """Return the sublist of already played cards;
+    call only on visible cards!"""
+    return list(filter\
+            (lambda x: int (x['name'][0]) <= progress[x['name'][1]], cards))
+
+def get_duplicate_cards(cards):
+    """Return the sublist of duplicate cards; call only on visible cards!"""
+    names = list(map(lambda x: x['name'], cards))
+    return list(filter(lambda x: names.count(x['name']) > 1, cards))
+
+def get_visible_cards(cards1, cards2):
+    """Return a list of the intersection of cards1 and cards2; call only on
+    visible cards!"""
+    names2 = map(lambda x: x['name'], cards2)
+    return list(filter(lambda x: x['name'] in names2, cards1))
+
+def get_nonvisible_cards(cards1, names2):
+    """Return a list of cards that are in cards1 but not names2; call only on
+    visible cards!"""
+    return list(filter(lambda x: x['name'] not in names2, cards1))
+
+def find_max(f, lst):
+    """Returns sublist of lst with all members x where f(x) is maximal"""
+    if len(lst) <= 1: # a little optimization if calling f is expensive
+        return lst
+    l = []
+    for x in lst:
+        value = f(x)
+        if 'highest' not in locals() or value > highest:
+            highest = value
+            l = [x]
+        elif value == highest:
+            l.append(x)
+    return l
+
+def find_min(f, lst):
+    """Analogous to find_max"""
+    if len(lst) <= 1:
+        return lst
+    l = []
+    for x in lst:
+        value = f(x)
+        if 'lowest' not in locals() or value < lowest:
+            lowest = value
+            l = [x]
+        elif value == lowest:
+            l.append(x)
+    return l
+
+def find_highest(cards):
+    """Returns list of cards with highest value in a list;
+    call only on visible cards!"""
+    return find_max (lambda x: int(x['name'][0]), cards)
+
+def find_lowest(cards):
+    """Analogous to find_highest"""
+    return find_min (lambda x: int(x['name'][0]), cards)
+
 
 def deduce_plays(cards, progress, suits):
     """Return a list of plays (subset of input); fine to call on own hand."""
@@ -53,3 +109,52 @@ def possibly_playable(card, progress, suits):
 def matches(name, hint):
     return (hint in name or (hint in VANILLA_SUITS and RAINBOW_SUIT in name))
 
+def other_players(me, r):
+    """Return a list of all players but me, in turn order starting after me"""
+    return list(range(me+1, r.nPlayers)) + list(range(0, me))
+
+def count_unique_future_plays(cards, progress):
+    """Returns the number of plays or future plays,
+    counting duplicate cards only once; call only on visible cards!"""
+    unique_names = list(set(map(lambda x: x['name'], cards)))
+    return len(list(filter(lambda x: int(x[0]) > progress[x[1]], unique_names)))
+
+def get_all_visible_cards(player, r):
+    """Returns list of visible cards for player"""
+    l = []
+    for i in other_players(player, r):
+        l.extend(r.h[i].cards)
+    return l
+
+def count_unplayed_cards(r, progress):
+    """Returns the number of cards which are not yet played, including cards
+    which are unplayable because all those cards (or cards of a value below it)
+    are already discarded"""
+    n = 0
+    for suit in r.suits:
+        n += 5 - progress[suit]
+    return n
+
+def count_unplayed_playable_cards(r, progress):
+    """Similar to count_unplayed_cards, but excluding the cards which are
+    unplayable because they are already discarded"""
+    n = 0
+    for suit in r.suits:
+        for i in range(progress[suit]+1,int(SUIT_CONTENTS[-1])+1):
+            if r.discardpile.count(str(i) + suit) < SUIT_CONTENTS.count(str(i)):
+                n += 1
+            else:
+                break
+    return n
+
+def can_see_all_useful_cards(me, r):
+    """Returns whether the player can see at least one copy of each card which is still playable"""
+    visible_cards = map(lambda x: x['name'], get_all_visible_cards(me, r))
+    for suit in r.suits:
+        for i in range(r.progress[suit]+1,int(SUIT_CONTENTS[-1])+1):
+            s = str(i) + suit
+            if r.discardpile.count(s) == SUIT_CONTENTS.count(str(i)):
+                break
+            if s not in visible_cards:
+                return False
+    return True

--- a/cheating_player.py
+++ b/cheating_player.py
@@ -6,7 +6,7 @@ table gives the approximate percentages of this strategy reaching maximum score
 
 Players | %
 --------+----
-   2    | 90
+   2    | 89
    3    | 98
    4    | 98
    5    | 97
@@ -18,67 +18,18 @@ Possible improvements (probably this doesn't actually increase the win percentag
 - When discarding a card you see in someone else's hand: don't do this if the
   other player has a lot of playable cards
 - When discarding the first copy of a card, prefer suits with low progress
+- In endgame, if I at least 2 more future plays than some teammate, clue instead of discard
+  (if enough clues)
 """
 
 from hanabi_classes import *
-from bot_utils import get_plays
+from bot_utils import *
 
-def get_played_cards(cards, progress):
-    """Return a list of already played cards; call only on visible cards!"""
-    return list(filter\
-            (lambda x: int (x['name'][0]) <= progress[x['name'][1]], cards))
-
-def get_duplicate_cards(cards):
-    """Return a list of duplicates in cards; call only on visible cards!"""
-    names = list(map(lambda x: x['name'], cards))
-    return list(filter(lambda x: names.count(x['name']) > 1, cards))
-
-def get_visible_cards(cards1, cards2):
-    """Return a list of the intersection of cards1 and cards2; call only on
-    visible cards!"""
-    names2 = map(lambda x: x['name'], cards2)
-    return list(filter(lambda x: x['name'] in names2, cards1))
-
-def get_nonvisible_cards(cards1, names2):
-    """Return a list of cards that are in cards1 but not names2; call only on
-    visible cards!"""
-    return list(filter(lambda x: x['name'] not in names2, cards1))
-
-def find_highest(cards):
-    """Return a list of cards from the input that have the highest value; call
-    only on visible cards!"""
-    highest = 0
-    l = []
-    for c in cards:
-        value = int(c['name'][0])
-        if value > highest:
-            highest = value
-            l = [c]
-        elif value == highest:
-            l.append(c)
-    return l
-
-def find_lowest(cards):
-    """Analogous to find_highest"""
-    lowest = 20 # Arbitrary large number
-    l = []
-    for c in cards:
-        value = int(c['name'][0])
-        if value < lowest:
-            lowest = value
-            l = [c]
-        elif value == lowest:
-            l.append(c)
-    return l
-
-def other_players(r, me):
-    """Return a list of all players but me, in turn order starting after me"""
-    return list(range(me+1, r.nPlayers)) + list(range(0, me))
 
 def get_all_visible_cards(player, r):
     """Return a list of the cards that player can see"""
     l = []
-    for i in other_players(r, player):
+    for i in other_players(player, r):
         l.extend(r.h[i].cards)
     return l
 
@@ -95,32 +46,36 @@ def count_unplayed_cards(r, progress):
 class CheatingPlayer:
 
     def want_to_discard(self, cards, player, r, progress):
-        """Returns a list (badness, card) where badness indicates how bad it is
+        """Returns a pair (badness, card) where badness indicates how bad it is
         to discard one of the cards for player and card is the least bad option.
-        badness = 0: discard useless card
-        badness = 1: discard card which is already in some else's hand
+        (badness = 0 is used if someone can play a card and doesn't have to
+          discard)
+        badness = 1: discard useless card
+        badness = 2: discard card which is already in some else's hand
         badness between 10 and 30: discard the first copy of a non-5 card (4s
         are badness 10, 3s badness 20, 2s badness 30)
         badness >= 100: discard a necessary card"""
         discardCards = get_played_cards(cards, progress)
         if discardCards: # discard a card which is already played
-            return [0, random.choice(discardCards)]
+            return 1, random.choice(discardCards)
         discardCards = get_duplicate_cards(cards)
         if discardCards: # discard a card which occurs twice in your hand
-            return [0, random.choice(discardCards)]
+            return 1, random.choice(discardCards)
         discardCards = get_visible_cards(cards, get_all_visible_cards(player,r))
         if discardCards: # discard a card which you can see (lowest first)
             discardCards = find_lowest(discardCards)
-            return [1, random.choice(discardCards)]
+            return 2, random.choice(discardCards)
+        # note: we never reach this part of the code if there is a 1 in the
+        # hand of player
         discardCards = get_nonvisible_cards(cards, r.discardpile)
         discardCards = list(filter(lambda x: x['name'][0] != '5', discardCards))
         if discardCards: # discard a card which is not unsafe to discard
             discardCards = find_highest(discardCards)
             card = random.choice(discardCards)
-            return [50 - 10 * int(card['name'][0]), card]
+            return 50 - 10 * int(card['name'][0]), card
         discardCards = find_highest(cards)
         card = random.choice(discardCards)
-        return [600 - 100 * int(card['name'][0]), card]
+        return 600 - 100 * int(card['name'][0]), card
 
     def play(self, r):
         me = r.whoseTurn
@@ -128,32 +83,37 @@ class CheatingPlayer:
         cards = r.h[me].cards
         progress = r.progress
 
+        # determine whether the game is in the endgame
+        # (this can cause the player to clue instead of discard)
+        if 0 < len(r.deck) < count_unplayed_cards(r, progress):
+            endgame = count_unplayed_playable_cards(r, progress) - len(r.deck)
+        else:
+            endgame = 0
+
         playableCards = get_plays(cards, progress)
-        if playableCards: # can I play?
+        if playableCards: # Play a card, if possible (lowest value first)
             wanttoplay = find_lowest(playableCards)
             return 'play', random.choice(wanttoplay)
 
-        if r.hints == 8: # Hint if you are at maximum hints and cannot play.
+        if r.hints == 8: # Hint if you are at maximum hints
             return 'hint', (nextplayer, '5')
-        # In endgame, don't discard if someone else can play.
-        someone_can_play = False
-        for i in other_players(r, me)[0:r.hints]:
-            if get_plays(r.h[i].cards, progress):
-                someone_can_play = True
-        if len(r.deck) < count_unplayed_cards(r, progress) and someone_can_play:
-            assert r.hints > 0
-            return 'hint', (nextplayer, '4')
-        badness, discard = self.want_to_discard(cards, me, r, progress)
+
+        if endgame > 0:
+            someone_can_play = False
+            for i in other_players(me, r)[0:r.hints]:
+                if get_plays(r.h[i].cards, progress):
+                    someone_can_play = True
+                    break
+            if someone_can_play:
+                assert r.hints > 0
+                return 'hint', (nextplayer, '4')
+
         # Discard if you can safely discard or if you have no hints.
-        #
-        # TODO: increase discard badness if you already have a lot of unique
-        # cards (cards which still needs playing, and where all other copies are
-        # already discarded) in your hand
-        #
+        badness, discard = self.want_to_discard(cards, me, r, progress)
         if badness < 10 or r.hints == 0:
             return 'discard', discard
         other_badness = []
-        for i in other_players(r, me)[0:r.hints]:
+        for i in other_players(me, r)[0:r.hints]:
             if get_plays(r.h[i].cards, progress):
                 other_badness.append(0)
             else:
@@ -166,4 +126,5 @@ class CheatingPlayer:
         #
         if min(other_badness) < badness:
             return 'hint', (nextplayer, '3')
+        # discard the highest critical card
         return 'discard', discard

--- a/cheating_player.py
+++ b/cheating_player.py
@@ -11,7 +11,7 @@ Players | %
    4    | 98
    5    | 97
 
-Possible improvements:
+Possible improvements (probably this doesn't actually increase the win percentage):
 - When playing a card, prefer one you don't see in someone else's hand
 - When playing a card, prefer one that allows other players to follow up in the
   same suit

--- a/hanabi_classes.py
+++ b/hanabi_classes.py
@@ -49,7 +49,7 @@ class Round:
     discardpile: list of (names of) cards which are discarded
     """
 
-    def __init__(self, gameType, names, verbosity):
+    def __init__(self, gameType, players, names, verbosity):
         """Instantiate a Round and its Hand sub-objects."""
         self.gameType  = gameType
         self.suits = VANILLA_SUITS
@@ -79,6 +79,7 @@ class Round:
         self.logger = logging.getLogger('game_log')
 
         self.NameRecord = names # Added so that AI can check what players it is playing with
+        self.PlayerRecord = players
         self.DropIndRecord = [] # Keeps track of the index of the dropped card
         self.Resign = False
         self.discardpile = []

--- a/hanabi_wrapper.py
+++ b/hanabi_wrapper.py
@@ -27,6 +27,7 @@ from newest_card_player import NewestCardPlayer
 from human_player import HumanPlayer
 from encoding_player import EncodingPlayer
 from general_encoding_player import GeneralEncodingPlayer
+from hat_player import HatPlayer
 
 # Define all available players.
 availablePlayers = {'idiot'   : CheatingIdiotPlayer, ### TODO: ADD YOURS
@@ -36,7 +37,8 @@ availablePlayers = {'idiot'   : CheatingIdiotPlayer, ### TODO: ADD YOURS
                     'newest'  : NewestCardPlayer,
                     'human'   : HumanPlayer,
                     'encoder' : EncodingPlayer,
-                    'gencoder': GeneralEncodingPlayer}
+                    'gencoder': GeneralEncodingPlayer
+                    'hat'     : HatPlayer}
 
 # Parse command-line args.
 parser = argparse.ArgumentParser(description='Process some integers.')

--- a/hanabi_wrapper.py
+++ b/hanabi_wrapper.py
@@ -15,6 +15,7 @@ Command-line arguments (see usage):
 import sys, argparse, logging, random
 from time import gmtime, strftime
 from scipy import stats, mean
+from math import sqrt
 from play_hanabi import play_one_round
 from hanabi_classes import SUIT_CONTENTS
 
@@ -123,11 +124,16 @@ for i in range(args.n_rounds):
 if args.verbosity != 'silent':
     logger.info('')
 if len(scores) > 1: # Only print stats if there were multiple rounds.
-    max_score = int(SUIT_CONTENTS[-1]) * (5 if args.game_type == 'vanilla' else 6)
+    max_score = int(SUIT_CONTENTS[-1]) * \
+                (5 if args.game_type == 'vanilla' else 6)
     count_max = scores.count(max_score)
-    logger.info('AVERAGE SCORE: {} +/- {} (1 std. err.)'\
-                .format(str(mean(scores))[:5], str(stats.sem(scores))[:4]))
-    logger.info('PERFECT GAMES: {}%'
-                .format(str(100*count_max/ float(len(scores)))[:4]))
+    perfect_games = count_max/float(args.n_rounds)
+    # the sample standard deviation for the amount of perfect scores
+    std_perfect_games = sqrt(count_max * (args.n_rounds - count_max) / \
+                             float (args.n_rounds - 1)) / args.n_rounds
+    logger.info('AVERAGE SCORE: {:.2f} +/- {:.3f} (1 std. err.)'\
+                .format(mean(scores), stats.sem(scores)))
+    logger.info('PERFECT GAMES: {:.2f}% +/- {:.2f}pp'
+                .format(100*fraction, 100*std_perfect_games))
 elif args.verbosity == 'silent': # Still print score for silent single round
     logger.info('Score: ' + str(scores[0]))

--- a/hanabi_wrapper.py
+++ b/hanabi_wrapper.py
@@ -38,7 +38,7 @@ availablePlayers = {'idiot'   : CheatingIdiotPlayer, ### TODO: ADD YOURS
                     'newest'  : NewestCardPlayer,
                     'human'   : HumanPlayer,
                     'encoder' : EncodingPlayer,
-                    'gencoder': GeneralEncodingPlayer
+                    'gencoder': GeneralEncodingPlayer,
                     'hat'     : HatPlayer}
 
 # Parse command-line args.
@@ -133,7 +133,7 @@ if len(scores) > 1: # Only print stats if there were multiple rounds.
                              float (args.n_rounds - 1)) / args.n_rounds
     logger.info('AVERAGE SCORE: {:.2f} +/- {:.3f} (1 std. err.)'\
                 .format(mean(scores), stats.sem(scores)))
-    logger.info('PERFECT GAMES: {:.2f}% +/- {:.2f}pp'
-                .format(100*fraction, 100*std_perfect_games))
+    logger.info('PERFECT GAMES: {:.2f}% +/- {:.2f}pp (1 std. err.)'
+                .format(100*perfect_games, 100*std_perfect_games))
 elif args.verbosity == 'silent': # Still print score for silent single round
     logger.info('Score: ' + str(scores[0]))

--- a/hat_player.py
+++ b/hat_player.py
@@ -93,7 +93,7 @@ class HatPlayer:
         """
         assert self != r.PlayerRecord[me] # this is never called on a player's own hand, so `self` can look at the hand of "me"
         # Do I want to play?
-        playableCards = filter(lambda x: x['name'] not in dont_play, get_plays(cards, progress))
+        playableCards = list(filter(lambda x: x['name'] not in dont_play, get_plays(cards, progress)))
         if playableCards:
             wanttoplay = find_lowest(playableCards)[0]
             return cards.index(wanttoplay)
@@ -118,31 +118,31 @@ class HatPlayer:
         x = self.standard_play(cards, player, dont_play, progress, decksize, hints, r)
         if x < 4:
             if self.min_futurehints <= 0 and cards[x]['name'][0] != '5':
-                playablefives = filter(lambda x: x['name'][0] == '5' and x['name'] not in dont_play, get_plays(cards, progress))
+                playablefives = list(filter(lambda x: x['name'][0] == '5' and x['name'] not in dont_play, get_plays(cards, progress)))
                 if playablefives:
                     if r.verbose:
-                        print 'play a 5 instead'
+                        print('play a 5 instead')
                     return cards.index(playablefives[0])
             return x
         if self.max_futurehints >= 8:
             if x < 8 and r.verbose:
-                print 'clue instead'
+                print('clue instead')
             return 8
         if (not self.cards_drawn) and self.futuredecksize == len(r.deck) and x == 8 and r.verbose:
-            print 'nobody can play!'
+            print('nobody can play!')
         if (self.min_futurehints <= 0 or ((not self.cards_drawn) and self.futuredecksize == len(r.deck))) and x == 8:
             y = self.easy_discards(cards, dont_play, progress, r)
             if y:
                 if r.verbose:
-                    print 'discard instead'
+                    print('discard instead')
                 return y
             y = self.hard_discards(cards, dont_play, progress, r)
             if y:
                 if r.verbose:
-                    print 'discard instead (ouch)'
+                    print('discard instead (ouch)')
                 return y
             if r.verbose:
-                print 'all cards are critical!', progress
+                print('all cards are critical!', progress)
         return x
 
 
@@ -155,7 +155,7 @@ class HatPlayer:
         discardCards = get_duplicate_cards(cards)
         if discardCards: # discard a card which occurs twice in your hand
             return cards.index(discardCards[0]) + 4
-        discardCards = filter(lambda x: x['name'] in dont_play, cards)
+        discardCards = list(filter(lambda x: x['name'] in dont_play, cards))
         if discardCards: # discard a card which will be played by this clue
             return cards.index(discardCards[0]) + 4
         # Otherwise clue
@@ -164,7 +164,7 @@ class HatPlayer:
     def hard_discards(self, cards, dont_play, progress, r):
         """Find the least bad card to discard"""
         discardCards = get_nonvisible_cards(cards, r.discardpile + self.futurediscarded)
-        discardCards = filter(lambda x: x['name'][0] != '5', discardCards)
+        discardCards = list(filter(lambda x: x['name'][0] != '5', discardCards))
         assert all(map(lambda x: x['name'][0] != '1', discardCards))
         if discardCards: # discard a card which is not unsafe to discard
             discardCards = find_highest(discardCards)
@@ -195,7 +195,7 @@ class HatPlayer:
         """Returns number corresponding to a clue. Returns -1 on clues not matching the pattern"""
         if clue == '5':
             if r.verbose:
-                print "Invalid clue received"
+                print("Invalid clue received")
             return -1
         if clue in '1234':
             return int(clue) - 1
@@ -216,11 +216,11 @@ class HatPlayer:
         for i in other_players(me, r):
             r.PlayerRecord[i].think_out_of_turn(i, me, myaction, r)
         if myaction[0] == 'discard' and r.hints == 8 and r.verbose:
-            print "Cheating! Discarding with 8 available hints"
+            print("Cheating! Discarding with 8 available hints")
         if myaction[0] == 'discard' and 0 < len(r.deck) < count_unplayed_playable_cards(r, r.progress) and r.verbose:
-            print "Discarding in endgame"
+            print("Discarding in endgame")
         if myaction[0] == 'play' and r.hints == 8 and cards[myaction[1]]['name'][0] == '5' and r.verbose:
-            print "Wasting a clue"
+            print("Wasting a clue")
         if myaction[0] == 'hint':
             return myaction
         else:
@@ -271,8 +271,8 @@ class HatPlayer:
                 if self.futurehints == 8:
                     self.max_futurehints = 9
                     if r.verbose:
-                        print 'Someone will not be able to discard. (now', r.hints, 'hints). Also deck will be', self.futuredecksize,\
-                            '- hints', self.futurehints, '- progress', self.futureprogress
+                        print('Someone will not be able to discard. (now', r.hints, 'hints). Also deck will be', self.futuredecksize,\
+                            '- hints', self.futurehints, '- progress', self.futureprogress)
                 else:
                     self.futurehints += 1
                     self.max_futurehints = max(self.futurehints, self.max_futurehints)
@@ -283,13 +283,13 @@ class HatPlayer:
                 if self.futurehints < 0:
                     self.futurehints = 1
                     if r.verbose:
-                        print 'Someone will not be able to clue. (now', r.hints, 'hints). Also deck will be', self.futuredecksize,\
-                            '- hints', self.futurehints, '- progress', self.futureprogress, self.min_futurehints
+                        print('Someone will not be able to clue. (now', r.hints, 'hints). Also deck will be', self.futuredecksize,\
+                            '- hints', self.futurehints, '- progress', self.futureprogress, self.min_futurehints)
                 if self.futurehints > 8:
                     self.futurehints = 8
                     if r.verbose:
-                        print 'A hint will be wasted. (now', r.hints, 'hints). Also deck will be', self.futuredecksize,\
-                            '- hints', self.futurehints, '- progress', self.futureprogress
+                        print('A hint will be wasted. (now', r.hints, 'hints). Also deck will be', self.futuredecksize,\
+                            '- hints', self.futurehints, '- progress', self.futureprogress)
 
     def play(self, r):
         me = r.whoseTurn
@@ -313,22 +313,23 @@ class HatPlayer:
         # Is there a clue aimed at me?
         if self.im_clued:
             myaction = self.number_to_action(self.clue_value)
-            if myaction[0] != 'play' and len(r.deck) == 0 and self.later_clues and (not get_plays(get_all_visible_cards(me, r), progress)):
-                print 'I could have been hinted about a card here'
+            if myaction[0] != 'play' and len(r.deck) == 0 and self.later_clues and (not get_plays(get_all_visible_cards(me, r), progress)) and count_unplayed_playable_cards(r, progress):
+                print('I could have been hinted about a card here',
+                    count_unplayed_cards(r, progress))
             # I'm going to do myaction. The first component is 'hint', 'discard' or 'play' and it happens on card with position 'pos' in my hand.
             # Before I send my move, the other players may think about what this move means
             if myaction[0] == 'discard' and r.hints > 1 and self.last_clued_any_clue == me and get_plays(r.h[(me + 1) % n].cards, progress):
                 if r.verbose:
-                    print 'Ignoring my discard hint. Cluing instead.', progress, r.hints
+                    print('Ignoring my discard hint. Cluing instead.', progress, r.hints)
             elif myaction[0] == 'play' or (myaction[0] == 'discard' and r.hints < N_HINTS):
                 return self.execute_action(myaction, r)
             if myaction[0] == 'discard' and r.hints == N_HINTS and r.verbose:
-                print 'Cannot discard, max clues'
+                print('Cannot discard, max clues')
         else:
             assert self.last_clued_any_clue == (me - 1) % n
         if not r.hints: # it is quite bad if this happens (but it is quite rare)
             if r.verbose:
-                print "Cannot clue, because there are no available hints"
+                print("Cannot clue, because there are no available hints")
             return self.execute_action(('discard', 3), r)
 
         # If there is no hint aimed at me, or I was hinted to give a hint myself, then I'm going to give a hint

--- a/hat_player.py
+++ b/hat_player.py
@@ -1,0 +1,173 @@
+"""A smart hat guessing Hanabi player.
+
+A strategy for 4 or 5 players which uses "hat guessing" to convey information to all other players with a single clue
+The following table gives the approximate percentages of this strategy reaching maximum score (using 6 suits).
+Players | %
+--------+----
+   2    | ??
+   3    | ??
+   4    | ??
+   5    | ??
+"""
+
+from hanabi_classes import *
+from bot_utils import *
+
+class HatPlayer:
+    def standard_play(self, cards, player, dont_play, r, progress):
+        """Returns a number 0-8 coding which action should be taken.
+        0-3 means play card 0-3.
+        4-7 means discard card 0-3
+        8 means clue something."""
+        return 0
+
+    def number_to_action(self, n, player, r):
+        """Returns action corresponding to a number."""
+        if n < 4:
+            return 'play', r.h[player].cards[n]
+        elif n < 8:
+            return 'discard', r.h[player].cards[n-4]
+        return 'hint', 0
+
+    def action_to_number(self, play):
+        """Returns number corresponding to an action. """
+        if play[0] == 'hint':
+            return 8
+        return play[1] + (0 if play[0] == 'play' else 4)
+
+    def clue_to_number(self, clue):
+        """Returns number corresponding to a clue."""
+        if clue in '12345':
+            return int(clue) - 1
+        return 4 + VANILLA_SUITS.find(clue)
+
+    def number_to_clue(self, n):
+        """Returns number corresponding to a clue."""
+        if n < 4:
+            return str(n+1)
+        return VANILLA_SUITS[n-4]
+
+    def print_debug(self, r, me):
+        """ print information for debugging purposes at the start of the game."""
+        print [1,2,3,4,5][-1:]
+        print [1,2,3,4,5][-0:]
+        pass
+        # for i in range(9):
+        #     print str(i) + ', ' + str(self.number_to_clue(i)) + ', ' + str(self.clue_to_number(self.number_to_clue(i)))
+        # for i in range(9):
+        #     print str(i) + ', ' + str(self.number_to_action(i, me, r))
+        # for i in range(4):
+        #     print 'play ' + str(i) + ', ' + str(self.action_to_number(('play',i)))
+        # for i in range(4):
+        #    print 'discard ' + str(i) + ', ' + str(self.action_to_number(('discard',i)))
+        # print 'hint, ' + str(self.action_to_number(('hint', 0)))
+
+    def play(self, r):
+        if r.nPlayers <= 3:
+            raise NameError('This AI works only with at least 4 players.')
+        me = r.whoseTurn
+        n = r.nPlayers
+        progress = r.progress
+        if len(r.playHistory) == 0:
+            self.print_debug(r, me)
+        im_clued = False # Am I already clued by someone?
+        player = me      # player being iterated over
+        l = []           # players numbers between me and player
+        actions = []     # actions of players since last clue
+        isfirstclue = True
+        for play in r.playHistory[:-(2*n):-1]:
+            player = (player - 1) % n
+            l.append(player)
+            if play[0] != 'hint':
+                continue
+            if isfirstclue:
+                if play[1][0] in l:
+                    break # I'm not clued
+                im_clued = True
+                first_clued = (player + 1) % n           # the first player clued by this clue (might change depending on previous clue)
+                last_clued  = play[1][0]                 # the last player clued by this clue
+                clue_value  = self.clue_to_number(play[1][1]) # the value clued
+                isfirstclue = False
+                l = [player]
+            else:
+                if play[1][0] not in l:
+                    first_clued = (play[1][0] + 1) % n
+                break
+        if im_clued:
+            clued_plays = (me - first_clued) % n # number of players which already responded to the clue
+            s = 0                                # sum of actions done so far
+            # print str(first_clued) + ', ' + str(last_clued) + ', ' + str(clue_value) + ', ' + str(clued_plays)
+            if clued_plays:
+                for play in r.playHistory[-clued_plays:]:
+                    s += self.action_to_number(('hint', 0)) # FIX
+            # for players between me and last clued: add standard_play to s
+            my_action = (clue_value - s) % n
+            print number_to_action(my_action, me, r)
+            # return
+        # find best clue to give
+
+
+        # remove all old code below this:
+
+        nextplayer = (me + 1) % r.nPlayers
+
+        # Play a card, if possible (lowest value first)
+        playableCards = get_plays(cards, progress)
+        if playableCards:
+            wanttoplay = find_lowest(playableCards)
+            return 'play', random.choice(wanttoplay)
+
+        # Hint if at maximum hints
+        if r.hints == N_HINTS:
+            return 'hint', (nextplayer, '5')
+        # don't discard in endgame if someone else can play (before you run out of hints)
+        someone_can_play = False
+        for i in other_players(me, r)[0:r.hints]:
+            if get_plays(r.h[i].cards, progress):
+                someone_can_play = True
+        if len(r.deck) < count_unplayed_cards(r, progress) and someone_can_play:
+            assert r.hints > 0
+            return 'hint', (nextplayer, '4')
+        # discard if you can safely discard or if you have no hints
+        badness, discard = self.want_to_discard(cards, me, r, progress)
+        if badness < 10 or r.hints == 0:
+            return 'discard', discard
+        # if someone can play or discard more safely before you run out of hints, give a hint
+        other_badness = []
+        for i in other_players(me, r)[0:r.hints]:
+            if get_plays(r.h[i].cards, progress):
+                other_badness.append(0)
+            else:
+                other_badness.append(self.want_to_discard(r.h[i].cards, i, r, progress)[0])
+        other_badness = other_badness
+        if min(other_badness) < badness:
+            return 'hint', (nextplayer, '3')
+        # discard the highest critical card
+        return 'discard', discard
+
+    def want_to_discard(self, cards, player, r, progress):
+        """Returns a pair (badness, card) where i is a number indicating how bad it is to discard one of the cards for player and card is a card which is least bad to discard.
+        (badness = 0 is used if someone can play a card and doesn't have to discard)
+        badness = 1: discard useless card
+        badness = 2: discard card which is already in some else's hand
+        badness between 10 and 30: discard the first copy of a non-5 card (4s are badness 10, 3s badness 20, 2s badness 30)
+        badness >= 100: discard a necessary card"""
+        discardCards = get_played_cards(cards, progress)
+        if discardCards: # discard a card which is already played
+            return 1, random.choice(discardCards)
+        discardCards = get_duplicate_cards(cards)
+        if discardCards: # discard a card which occurs twice in your hand
+            return 1, random.choice(discardCards)
+        discardCards = get_visible_cards(cards, get_all_visible_cards(player, r))
+        if discardCards: # discard a card which you can see (lowest first)
+            discardCards = find_lowest(discardCards)
+            return 2, random.choice(discardCards)
+        discardCards = get_nonvisible_cards(cards, r.discardpile)
+        discardCards = filter(lambda x: x['name'][0] != '5', discardCards)
+        if discardCards: # discard a card which is not unsafe to discard
+            discardCards = find_highest(discardCards)
+            card = random.choice(discardCards)
+            return 50 - 10 * int(card['name'][0]), card
+        discardCards = find_highest(cards)
+        card = random.choice(discardCards)
+        return 600 - 100 * int(card['name'][0]), card

--- a/hat_player.py
+++ b/hat_player.py
@@ -1,27 +1,33 @@
 """A smart hat guessing Hanabi player.
 
-A strategy for 4 or 5 players which uses "hat guessing" to convey information to all other players with a single clue
-The following table gives the approximate percentages of this strategy reaching maximum score.
+A strategy for 4 or 5 players which uses "hat guessing" to convey information
+to all other players with a single clue. The following table gives the
+approximate percentages of this strategy reaching maximum score.
 Players | % (6 suits) | % (5 suits)
 --------+-------------+------------
    4    |     79      |     84
    5    |     87      |    79-80
 
 Major mistakes:
-- the last 5 should be hinted more flexibly (if player n plays the 4, and the player after it has the 5, players can clue that 5 by giving a play hint even though that doesn't make sense)
-
+- the last 5 should be hinted more flexibly (if player n plays the 4, and the
+player after it has the 5, players can clue that 5 by giving a play hint even
+though that doesn't make sense)
+- Giving hints which will instruct a player to hint without hints
 
 Improvements in standard_play: (all improvements are very small)
-- allow discarding of cards in (some) other players' hands (after clue-receiver and before clue-giver (both strictly))
+- allow discarding of cards in (some) other players' hands (after clue-receiver
+    and before clue-giver (both strictly))
 - prefer to play cards which are already discarded
 
 Improvements in clue giving (to next player):
-- Clue easy_discard to next player if (clued plays + possible plays afterwards < 3)
+- Clue easy_discard to next player if
+    (clued plays + possible plays afterwards) < 3
 - Clue 'hint' instead of discard near the end of the game
 
 
 Improvements in other play:
-If I have a discard action and no other players are clued: decide whether it is better to clue (complicated to implement, and probably not really better)
+If I have a discard action and no other players are clued: decide whether it is
+better to clue (complicated to implement, and probably not really better)
 """
 
 from hanabi_classes import *
@@ -32,17 +38,25 @@ class HatPlayer:
     def reset_memory(self):
         """(re)set memory to standard values except last_clued
 
-        All players have some memory about the state of the game, and two functions 'interpret_clue' and 'think_out_of_turn' will update memory during opponents' turns.
-        This does *not* reset last_clued_any_clue, since that variable should not be reset during the round."""
+        All players have some memory about the state of the game, and two
+        functions 'interpret_clue' and 'think_out_of_turn' will update memory
+        during opponents' turns.
+        This does *not* reset last_clued_any_clue, since that variable should
+        not be reset during the round."""
         self.im_clued = False         # Am I being clued?
         self.first_clued = -1         # The first player clued by that clue
         self.last_clued = -1          # The last player clued by that clue
-        self.clue_value = -1          # The value of that clue (see description of "standard_play")
-        self.next_player_actions = [] # what the other players will do with that clue, in reverse order
-        self.later_clues = []         # information of all later clues given after the clue given to me as pairs (target, value).
+        # The value of that clue (see description of "standard_play")
+        self.clue_value = -1
+        # what the other players will do with that clue, in reverse order
+        self.next_player_actions = []
+        # information of all later clues given after the clue given to me
+        #  as pairs (target, value).
+        self.later_clues = []
 
     def interpret_clue(self, me, r):
-        """ self (players[me]) interprets a given clue to him. This is done at the start of the turn of the player who was first targeted by this clue
+        """ self (players[me]) interprets a given clue to him. This is done at
+        the start of the turn of the player who was first targeted by this clue.
         This function accesses only information known to `me`."""
         if not (self.im_clued and self.first_clued == r.whoseTurn):
             return
@@ -52,20 +66,25 @@ class HatPlayer:
         self.initialize_future_clue(r)
         i = self.last_clued
         while i != me:
-            x = self.standard_play(r.h[i].cards, i, self.will_be_played, r.progress, len(r.deck), r.hints, r)
+            x = self.standard_play(r.h[i].cards, i, self.will_be_played, \
+                                   r.progress, len(r.deck), r.hints, r)
             self.next_player_actions.append(x)
             self.clue_value = (self.clue_value - x) % 9
             self.finalize_future_action(x, i, me, r)
             i = (i - 1) % n
 
     def think_out_of_turn(self, me, player, action, r):
-        """ self (players[me]) thinks out of turn during the turn of `me`. This function accesses only information known to `me`."""
+        """ self (players[me]) thinks out of turn during the turn of `me`.
+        This function accesses only information known to `me`."""
         n = r.nPlayers
-        if self.last_clued_any_clue == (player - 1) % n: # This happens if n-1 players in a row don't clue
+        # The following happens if n-1 players in a row don't clue
+        if self.last_clued_any_clue == (player - 1) % n:
             self.last_clued_any_clue = player
         # Update the clue value given to me
-        if self.im_clued and self.is_between(player, self.first_clued, self.last_clued):
-            self.clue_value = (self.clue_value - self.action_to_number(action)) % 9
+        if self.im_clued and\
+        self.is_between(player, self.first_clued, self.last_clued):
+            self.clue_value = \
+            (self.clue_value - self.action_to_number(action)) % 9
         if action[0] != 'hint':
             return
         target, value = action[1]
@@ -85,15 +104,19 @@ class HatPlayer:
         self.later_clues = []
 
 
-    def standard_play(self, cards, me, dont_play, progress, decksize, hints, r): # TODO: maybe add dont_discard argument? Also: allow discarding cards in dont_play
-        """Returns a number 0-8 coding which action should be taken by player `me`.
+    def standard_play(self, cards, me, dont_play, progress, decksize, hints, r):
+        # TODO: maybe add dont_discard argument?
+        """Returns a number 0-8 coding which action should be taken by player
+        `me`.
         0-3 means play card 0-3.
         4-7 means discard card 0-3
         8 means clue something.
         """
-        assert self != r.PlayerRecord[me] # this is never called on a player's own hand, so `self` can look at the hand of "me"
+        # this is never called on a player's own hand
+        assert self != r.PlayerRecord[me]
         # Do I want to play?
-        playableCards = list(filter(lambda x: x['name'] not in dont_play, get_plays(cards, progress)))
+        playableCards = list(filter(lambda x: x['name'] not in dont_play,\
+                                    get_plays(cards, progress)))
         if playableCards:
             wanttoplay = find_lowest(playableCards)[0]
             return cards.index(wanttoplay)
@@ -110,27 +133,41 @@ class HatPlayer:
         else:
             return 8
 
-    def modified_play(self, cards, hinter, player, dont_play, progress, decksize, hints, r): # TODO: maybe add dont_discard argument? Also: allow discarding cards in dont_play
-        """Modified play for the first player the cluegiver clues
-        """
-        assert self != r.PlayerRecord[player] # this is never called on a player's own hand, so `self` can look at the hand of "me"
+    def modified_play(self, cards, hinter, player, dont_play, progress,\
+                      decksize, hints, r):
+        # TODO: maybe add dont_discard argument?
+        """Modified play for the first player the cluegiver clues. This play can
+        be smarter than standard_play"""
+        # this is never called on a player's own hand
+        assert self != r.PlayerRecord[player]
         assert self == r.PlayerRecord[hinter]
-        x = self.standard_play(cards, player, dont_play, progress, decksize, hints, r)
+        x = self.standard_play(cards, player, dont_play, progress, decksize,\
+                               hints, r)
+        # If you were instructed to play, and you can play a 5 which will help
+        # a future person to discard, do that.
         if x < 4:
             if self.min_futurehints <= 0 and cards[x]['name'][0] != '5':
-                playablefives = list(filter(lambda x: x['name'][0] == '5' and x['name'] not in dont_play, get_plays(cards, progress)))
+                playablefives = list(filter(lambda x: x['name'][0] == '5',\
+                                            get_plays(cards, progress)))
                 if playablefives:
                     if r.verbose:
                         print('play a 5 instead')
                     return cards.index(playablefives[0])
             return x
+        # If too much players will discard, hint instead of discarding.
         if self.max_futurehints >= 8:
             if x < 8 and r.verbose:
                 print('clue instead')
             return 8
-        if (not self.cards_drawn) and self.futuredecksize == len(r.deck) and x == 8 and r.verbose:
+        if (not self.cards_drawn) and self.futuredecksize == len(r.deck) and\
+           x == 8 and r.verbose:
             print('nobody can play!')
-        if (self.min_futurehints <= 0 or ((not self.cards_drawn) and self.futuredecksize == len(r.deck))) and x == 8:
+        # Sometimes you want to discard instead of hint. This happens if either
+        # - someone is instructed to hint without clues
+        # - everyone else will hint (which usually happens if nobody can play
+        #   and the deck is too small to safely discard
+        if x == 8 and (self.min_futurehints <= 0 or ((not self.cards_drawn) and\
+            self.futuredecksize == len(r.deck))):
             y = self.easy_discards(cards, dont_play, progress, r)
             if y:
                 if r.verbose:
@@ -163,7 +200,8 @@ class HatPlayer:
 
     def hard_discards(self, cards, dont_play, progress, r):
         """Find the least bad card to discard"""
-        discardCards = get_nonvisible_cards(cards, r.discardpile + self.futurediscarded)
+        discardCards = get_nonvisible_cards(cards, \
+                                        r.discardpile + self.futurediscarded)
         discardCards = list(filter(lambda x: x['name'][0] != '5', discardCards))
         assert all(map(lambda x: x['name'][0] != '1', discardCards))
         if discardCards: # discard a card which is not unsafe to discard
@@ -173,8 +211,10 @@ class HatPlayer:
 
 
     def is_between(self, x, begin, end):
-        """Returns whether x is between begin (inclusive) and end (inclusive) modulo the number of players.
-        This function assumes that x, begin, end are smaller than the number of players (and at least 0)"""
+        """Returns whether x is (in turn order) between begin and end
+        (inclusive) modulo the number of players. This function assumes that x,
+        begin, end are smaller than the number of players (and at least 0).
+        If begin == end, this is only true id x == begin == end."""
         return begin <= x <= end or end < begin <= x or x <= end < begin
 
     def number_to_action(self, n):
@@ -192,7 +232,8 @@ class HatPlayer:
         return play[1] + (0 if play[0] == 'play' else 4)
 
     def clue_to_number(self, clue):
-        """Returns number corresponding to a clue. Returns -1 on clues not matching the pattern"""
+        """Returns number corresponding to a clue.
+        Returns -1 on clues not matching the pattern"""
         if clue == '5':
             if r.verbose:
                 print("Invalid clue received")
@@ -208,8 +249,11 @@ class HatPlayer:
         return VANILLA_SUITS[n-4]
 
     def execute_action(self, myaction, r):
-        """In the play function return the final action which is executed. This also updates the memory of other players and resets the memory of the current player
-        the second component of myaction for play and discard is the *position* of that card in my hand"""
+        """In the play function return the final action which is executed.
+        This also updates the memory of other players and resets the memory of
+        the current player.
+        The second component of myaction for play and discard is the *position*
+        of that card in the hand"""
         me = r.whoseTurn
         cards = r.h[me].cards
         self.reset_memory()
@@ -217,9 +261,11 @@ class HatPlayer:
             r.PlayerRecord[i].think_out_of_turn(i, me, myaction, r)
         if myaction[0] == 'discard' and r.hints == 8 and r.verbose:
             print("Cheating! Discarding with 8 available hints")
-        if myaction[0] == 'discard' and 0 < len(r.deck) < count_unplayed_playable_cards(r, r.progress) and r.verbose:
+        if myaction[0] == 'discard' and 0 < len(r.deck) < \
+           count_unplayed_playable_cards(r, r.progress) and r.verbose:
             print("Discarding in endgame")
-        if myaction[0] == 'play' and r.hints == 8 and cards[myaction[1]]['name'][0] == '5' and r.verbose:
+        if myaction[0] == 'play' and r.hints == 8 and \
+           cards[myaction[1]]['name'][0] == '5' and r.verbose:
             print("Wasting a clue")
         if myaction[0] == 'hint':
             return myaction
@@ -228,17 +274,24 @@ class HatPlayer:
 
     def initialize_future_prediction(self, penalty, r):
         """Do this at the beginning of predicting future actions.
-        Penalty is 1 if you're currently cluing, meaning that there is one fewer turn after your turn"""
+        Penalty is 1 if you're currently cluing, meaning that there is one
+        fewer turn after your turn"""
         self.futureprogress = copy(r.progress)
         self.futuredecksize = len(r.deck)
         self.futurehints = r.hints - penalty
         self.futurediscarded = []
 
     def initialize_future_clue(self, r):
-        """When predicting future actions, do this at the beginning of predicting every clue"""
+        """When predicting future actions, do this at the beginning of
+        predicting every clue"""
         self.cards_drawn = 0
         self.will_be_played = []
-        self.hint_changes = [] # 1 means gain hint by playing a 5, 2 means gain hint by discarding, -1 means lose hint by cluing
+        # Meaning of entries in hint_changes:
+        # 1 means gain hint by playing a 5,
+        # 2 means gain hint by discarding,
+        # -1 means lose hint by cluing
+        # Note that the order of hint_changes is in reverse turn order.
+        self.hint_changes = []
 
     def finalize_future_action(self, action, i, me, r):
         """When predicting future actions, do this after every action"""
@@ -256,7 +309,8 @@ class HatPlayer:
             self.hint_changes.append(-1)
 
     def finalize_future_clue(self, r):
-        """When predicting future actions, do this at the end of predicting every clue."""
+        """When predicting future actions, do this at the end of predicting
+        every clue."""
         for p in self.will_be_played:
             self.futureprogress[p[1]] += 1
         self.futuredecksize = max(0, self.futuredecksize - self.cards_drawn)
@@ -271,25 +325,35 @@ class HatPlayer:
                 if self.futurehints == 8:
                     self.max_futurehints = 9
                     if r.verbose:
-                        print('Someone will not be able to discard. (now', r.hints, 'hints). Also deck will be', self.futuredecksize,\
-                            '- hints', self.futurehints, '- progress', self.futureprogress)
+                        print('Someone will not be able to discard. (now',\
+                              r.hints, 'hints). Also deck will be',\
+                              self.futuredecksize, '- hints', self.futurehints,\
+                              '- progress', self.futureprogress)
                 else:
                     self.futurehints += 1
-                    self.max_futurehints = max(self.futurehints, self.max_futurehints)
+                    self.max_futurehints = \
+                        max(self.futurehints, self.max_futurehints)
             else:
                 self.futurehints += i
-                self.max_futurehints = max(self.futurehints, self.max_futurehints)
-                self.min_futurehints = min(self.futurehints, self.min_futurehints)
+                self.max_futurehints = \
+                        max(self.futurehints, self.max_futurehints)
+                self.min_futurehints = \
+                        min(self.futurehints, self.min_futurehints)
                 if self.futurehints < 0:
                     self.futurehints = 1
                     if r.verbose:
-                        print('Someone will not be able to clue. (now', r.hints, 'hints). Also deck will be', self.futuredecksize,\
-                            '- hints', self.futurehints, '- progress', self.futureprogress, self.min_futurehints)
+                        print('Someone will not be able to clue. (now',\
+                              r.hints, 'hints). Also deck will be',\
+                              self.futuredecksize, '- hints', self.futurehints,\
+                              '- progress', self.futureprogress,\
+                              self.min_futurehints)
                 if self.futurehints > 8:
                     self.futurehints = 8
                     if r.verbose:
-                        print('A hint will be wasted. (now', r.hints, 'hints). Also deck will be', self.futuredecksize,\
-                            '- hints', self.futurehints, '- progress', self.futureprogress)
+                        print('A hint will be wasted. (now', r.hints,\
+                              'hints). Also deck will be', self.futuredecksize,\
+                              '- hints', self.futurehints, '- progress',\
+                              self.futureprogress)
 
     def play(self, r):
         me = r.whoseTurn
@@ -305,38 +369,58 @@ class HatPlayer:
             if r.nPlayers <= 3:
                 raise NameError('This AI works only with at least 4 players.')
             for i in range(n):
-                r.PlayerRecord[i].reset_memory() # initialize variables which contain the memory of this player. These are updated after every move of any player
-                r.PlayerRecord[i].last_clued_any_clue = n - 1 # the last player clued by any clue, not necessarily the clue which is relevant to me. This must be up to date all the time
-        # everyone takes some time to think about the meaning of previously given clues
+                # initialize variables which contain the memory of this player.
+                # These are updated after every move of any player
+                r.PlayerRecord[i].reset_memory()
+                # the last player clued by any clue, not necessarily the clue
+                # which is relevant to me. This must be up to date all the time
+                r.PlayerRecord[i].last_clued_any_clue = n - 1
+        # everyone takes some time to think about the meaning of previously
+        # given clues
         for i in range(n):
             r.PlayerRecord[i].interpret_clue(i, r)
         # Is there a clue aimed at me?
         if self.im_clued:
             myaction = self.number_to_action(self.clue_value)
-            if myaction[0] != 'play' and len(r.deck) == 0 and self.later_clues and (not get_plays(get_all_visible_cards(me, r), progress)) and count_unplayed_playable_cards(r, progress):
+            # In the endgame we might be able to change the meaning of hints to
+            # more efficiently clue who has the last remaining playable cards.
+            # Currently this only displays a message in certain cases where this
+            # would result in (at least) 1 more played cards.
+            if myaction[0] != 'play' and len(r.deck) == 0 and self.later_clues\
+               and (not get_plays(get_all_visible_cards(me, r), progress)) and\
+               count_unplayed_playable_cards(r, progress) and r.verbose:
                 print('I could have been hinted about a card here',
                     count_unplayed_cards(r, progress))
-            # I'm going to do myaction. The first component is 'hint', 'discard' or 'play' and it happens on card with position 'pos' in my hand.
-            # Before I send my move, the other players may think about what this move means
-            if myaction[0] == 'discard' and r.hints > 1 and self.last_clued_any_clue == me and get_plays(r.h[(me + 1) % n].cards, progress):
+            # I'm going to do myaction. The first component is 'hint', 'discard'
+            # or 'play' and it happens on card with position 'pos' in my hand.
+            # Before I send my move, the other players may think about what
+            # this move means
+            if myaction[0] == 'discard' and r.hints > 1 and\
+               self.last_clued_any_clue == me and\
+               get_plays(r.h[(me + 1) % n].cards, progress):
                 if r.verbose:
-                    print('Ignoring my discard hint. Cluing instead.', progress, r.hints)
-            elif myaction[0] == 'play' or (myaction[0] == 'discard' and r.hints < N_HINTS):
+                    print('Ignoring my discard hint. Cluing instead.',\
+                          progress, r.hints)
+            elif myaction[0] == 'play' or\
+                 (myaction[0] == 'discard' and r.hints < N_HINTS):
                 return self.execute_action(myaction, r)
             if myaction[0] == 'discard' and r.hints == N_HINTS and r.verbose:
                 print('Cannot discard, max clues')
         else:
             assert self.last_clued_any_clue == (me - 1) % n
-        if not r.hints: # it is quite bad if this happens (but it is quite rare)
+        if not r.hints: # it is quite bad if this happens (but it is not common)
             if r.verbose:
                 print("Cannot clue, because there are no available hints")
             return self.execute_action(('discard', 3), r)
 
-        # If there is no hint aimed at me, or I was hinted to give a hint myself, then I'm going to give a hint
+        # If there is no hint aimed at me, or I was hinted to give a hint
+        # myself, then I'm going to give a hint
         if self.last_clued_any_clue == (me - 1) % n:
             self.last_clued_any_clue = me
-        # First I have to figure out what will happen after my turn because of clues given earlier
-        # What will happen because of the clue given to me?
+        # Before I clue I have to figure out what will happen after my turn
+        # because of clues given earlier.
+        # The first step is to predict what will happen because of the clue
+        # given to me?
         self.initialize_future_prediction(1, r)
         self.initialize_future_clue(r)
         i = self.last_clued
@@ -345,13 +429,14 @@ class HatPlayer:
             i = (i - 1) % n
         self.finalize_future_clue(r)
 
-        # What will happen because of clues after that?
+        # What will happen because of clues given after that?
         first_target = (self.last_clued + 1) % n # the first target of next clue
         for last_target, value in self.later_clues:
             self.initialize_future_clue(r)
             i = last_target
             while i != first_target:
-                x = self.standard_play(r.h[i].cards, i, self.will_be_played, self.futureprogress, self.futuredecksize, self.futurehints, r)
+                x = self.standard_play(r.h[i].cards, i, self.will_be_played,\
+                  self.futureprogress, self.futuredecksize, self.futurehints, r)
                 self.finalize_future_action(x, i, me, r)
                 value = (value - x) % 9
                 i = (i - 1) % n
@@ -366,14 +451,16 @@ class HatPlayer:
         i = target
           # What should all players after the next player do?
         while i != (self.last_clued_any_clue + 1) % n:
-            x = self.standard_play(r.h[i].cards, i, self.will_be_played, self.futureprogress, self.futuredecksize, self.futurehints, r)
+            x = self.standard_play(r.h[i].cards, i, self.will_be_played,\
+                self.futureprogress, self.futuredecksize, self.futurehints, r)
             cluenumber = (cluenumber + x) % 9
             self.finalize_future_action(x, i, me, r)
             i = (i - 1) % n
-          # What should the next player do?
+        # What should the next player do?
         self.count_hints(r)
         assert i != me
-        x = self.modified_play(r.h[i].cards, me, i, self.will_be_played, self.futureprogress, self.futuredecksize, self.futurehints, r)
+        x = self.modified_play(r.h[i].cards, me, i, self.will_be_played,\
+                self.futureprogress, self.futuredecksize, self.futurehints, r)
         cluenumber = (cluenumber + x) % 9
 
 

--- a/hat_player.py
+++ b/hat_player.py
@@ -13,20 +13,95 @@ Players | %
 from hanabi_classes import *
 from bot_utils import *
 
+
+
 class HatPlayer:
-    def standard_play(self, cards, player, dont_play, r, progress):
-        """Returns a number 0-8 coding which action should be taken.
+    def reset_memory(self):
+        """(re)set memory to standard values except last_clued"""
+        self.im_clued = False # Am I being clued?
+        self.first_clued = -1 # The first player clued by that clue
+        self.last_clued = -1 # The last player clued by that clue
+        self.clue_value = -1  # The value of that clue (see "standard_play")
+        self.next_player_actions = [] # what the other players will do with that clue, in reverse order
+
+    def interpret_clue(self, me, r):
+        """ self (players[me]) interprets a given clue to him. This function accesses only information known to `me`"""
+        if not (self.im_clued and self.first_clued == r.whoseTurn):
+            return
+        n = r.nPlayers
+        self.next_player_actions = []
+        will_be_played = []
+        i = self.last_clued
+        while i != me:
+            x = self.standard_play(r.h[i].cards, i, will_be_played, r.progress, r.discardpile)
+            self.next_player_actions.append(x)
+            self.clue_value = (self.clue_value - x) % 9
+            if x < 4:
+                will_be_played.append(r.h[i].cards[x]['name'])
+            i = (i - 1) % n
+#        print 'Player', me+1, 'updates clue value to', self.clue_value
+
+    def think_out_of_turn(self, me, player, action, r):
+        """ self (players[me]) thinks out of turn during the turn of `me`. This function accesses only information known to `me`."""
+        n = r.nPlayers
+        if self.im_clued:
+            if self.is_between(player, self.first_clued, self.last_clued):
+                self.clue_value = (self.clue_value - self.action_to_number(action)) % 9
+            # else:
+            #     print 'Player', me+1, 'recognizes this play is not relevant for him.', self.first_clued, self.last_clued, self.clue_value, self.last_clued_any_clue
+            if action[0] == 'hint':
+                self.last_clued_any_clue = action[1][0]
+                # print 'Player', me+1, 'updates some information.', self.first_clued, self.last_clued, self.clue_value, self.last_clued_any_clue
+        elif action[0] == 'hint':
+            # print 'Player', me+1, 'thinks last_clued is', self.last_clued, player
+            target, value = action[1]
+            if value == '5':
+                return
+            if self.last_clued_any_clue == (player - 1) % n:
+                self.first_clued = (player + 1) % n
+            else:
+                self.first_clued = (self.last_clued_any_clue + 1) % n
+            self.last_clued = target
+            self.last_clued_any_clue = target
+            self.clue_value = self.clue_to_number(value)
+            if self.is_between(me, self.first_clued, self.last_clued):
+                self.im_clued = True
+
+                # print 'Player', me+1, 'thinks he is ' + ('' if self.im_clued else 'not ') + 'clued.', self.first_clued, self.last_clued, self.clue_value, self.last_clued_any_clue
+
+
+    def standard_play(self, cards, me, dont_play, progress, discardpile): # TODO: maybe add dont_discard argument? Also: allow discarding cards in dont_play
+        """Returns a number 0-8 coding which action should be taken by player `me`.
         0-3 means play card 0-3.
         4-7 means discard card 0-3
-        8 means clue something."""
-        return 0
+        8 means clue something.
+        Player p will never call standard_play on himself (i.e. p != players[me]), so we can freely look at the hand of `me`"""
+        # Do I want to play?
+        playableCards = filter(lambda x: x['name'] not in dont_play, get_plays(cards, progress))
+        if playableCards:
+            wanttoplay = find_lowest(playableCards)[0]
+            return cards.index(wanttoplay)
+        # Do I want to discard?
+        discardCards = get_played_cards(cards, progress)
+        if discardCards: # discard a card which is already played
+            return cards.index(discardCards[0]) + 4
+        discardCards = get_duplicate_cards(cards)
+        if discardCards: # discard a card which occurs twice in your hand
+            return cards.index(discardCards[0]) + 4
+        # Otherwise clue
+        return 8
 
-    def number_to_action(self, n, player, r):
+    def is_between(self, x, begin, end):
+        """Returns whether x is between begin (inclusive) and end (inclusive) modulo the number of players.
+        This function assumes that x, begin, end are smaller than the number of players (and at least 0)"""
+        return begin <= x <= end or end < begin <= x or x <= end < begin
+
+    def number_to_action(self, n):
         """Returns action corresponding to a number."""
         if n < 4:
-            return 'play', r.h[player].cards[n]
+            return 'play', n
         elif n < 8:
-            return 'discard', r.h[player].cards[n-4]
+            return 'discard', n - 4
         return 'hint', 0
 
     def action_to_number(self, play):
@@ -49,8 +124,6 @@ class HatPlayer:
 
     def print_debug(self, r, me):
         """ print information for debugging purposes at the start of the game."""
-        print [1,2,3,4,5][-1:]
-        print [1,2,3,4,5][-0:]
         pass
         # for i in range(9):
         #     print str(i) + ', ' + str(self.number_to_clue(i)) + ', ' + str(self.clue_to_number(self.number_to_clue(i)))
@@ -63,52 +136,51 @@ class HatPlayer:
         # print 'hint, ' + str(self.action_to_number(('hint', 0)))
 
     def play(self, r):
-        if r.nPlayers <= 3:
-            raise NameError('This AI works only with at least 4 players.')
         me = r.whoseTurn
         n = r.nPlayers
         progress = r.progress
+        # Debugging on the first turn
+        for i in r.NameRecord:
+            if i[:-1] != 'Hat':
+                raise NameError('Hat AI must only play with other hatters')
         if len(r.playHistory) == 0:
             self.print_debug(r, me)
-        im_clued = False # Am I already clued by someone?
-        player = me      # player being iterated over
-        l = []           # players numbers between me and player
-        actions = []     # actions of players since last clue
-        isfirstclue = True
-        for play in r.playHistory[:-(2*n):-1]:
-            player = (player - 1) % n
-            l.append(player)
-            if play[0] != 'hint':
-                continue
-            if isfirstclue:
-                if play[1][0] in l:
-                    break # I'm not clued
-                im_clued = True
-                first_clued = (player + 1) % n           # the first player clued by this clue (might change depending on previous clue)
-                last_clued  = play[1][0]                 # the last player clued by this clue
-                clue_value  = self.clue_to_number(play[1][1]) # the value clued
-                isfirstclue = False
-                l = [player]
-            else:
-                if play[1][0] not in l:
-                    first_clued = (play[1][0] + 1) % n
-                break
-        if im_clued:
-            clued_plays = (me - first_clued) % n # number of players which already responded to the clue
-            s = 0                                # sum of actions done so far
-            # print str(first_clued) + ', ' + str(last_clued) + ', ' + str(clue_value) + ', ' + str(clued_plays)
-            if clued_plays:
-                for play in r.playHistory[-clued_plays:]:
-                    s += self.action_to_number(('hint', 0)) # FIX
-            # for players between me and last clued: add standard_play to s
-            my_action = (clue_value - s) % n
-            print number_to_action(my_action, me, r)
-            # return
-        # find best clue to give
+            if r.nPlayers <= 3:
+                raise NameError('This AI works only with at least 4 players.')
+            for i in range(n):
+                r.PlayerRecord[i].reset_memory() # initialize variables which contain the memory of this player. These are updated after every move of any player
+                r.PlayerRecord[i].last_clued_any_clue = n - 1 # the last player clued by any clue, not necessarily the clue which is relevant to me. This must be up to date all the time
+        # everyone takes some time to think about the meaning of previously given clues
+        for i in range(n):
+            r.PlayerRecord[i].interpret_clue(i, r)
+        # Is there a clue aimed at me?
+        if self.im_clued:
+            myaction = self.number_to_action(self.clue_value)
+            # I'm going to do myaction. The first component is 'hint', 'discard' or 'play' and it happens on card with position 'pos' in my hand.
+            # Before I send my move, the other players may think about what this move means
+            self.reset_memory() # forget everything, except who the last clued player is (the only thing actually important to reset is `im_clued` to False
+            if myaction[0] != 'hint':
+                for i in other_players(me, r):
+                    r.PlayerRecord[i].think_out_of_turn(i, me, myaction, r)
+                return myaction[0], r.h[me].cards[myaction[1]]
+        else:
+            assert self.last_clued_any_clue == (me - 1) % n
+        assert r.hints
+        # If there is no hint aimed at me, or I was hinted to give a hint myself, then I'm going to give a hint
+        target = (me - 1) % n
+        clue = 'r'
+
+
+        # I'm going to clue (target, clue)
+        myaction = 'hint', (target, clue)
+        self.last_clued_any_clue = target
+        for i in other_players(me, r):
+            r.PlayerRecord[i].think_out_of_turn(i, me, myaction, r)
+        return myaction
 
 
         # remove all old code below this:
-
+        cards = r.h[me].cards
         nextplayer = (me + 1) % r.nPlayers
 
         # Play a card, if possible (lowest value first)

--- a/play_hanabi.py
+++ b/play_hanabi.py
@@ -9,7 +9,7 @@ from hanabi_classes import *
 
 def play_one_round(gameType, players, names, verbosity, lossScore):
     """Play a full round and return the score (int)."""
-    r = Round(gameType, names, verbosity) # Instance of a single Hanabi round
+    r = Round(gameType, players, names, verbosity) # Instance of a single Hanabi round
     r.generate_deck_and_deal_hands()
 
     while r.gameOverTimer != 0:


### PR DESCRIPTION
This pull request adds a new player `hat` which uses hat guessing techniques to give clues. The basic idea of the strategy is the "recommendation strategy" of the paper `How to Make the Perfect Fireworks Display: Two Strategies for Hanabi.`
However, I've improved their strategy a lot, so that it gets a perfect score about 80% of the time instead of 16% of the time in the paper. I can explain some improvements if someone is interested, because I'm not sure how readable my code is. The strategy only works for 4+ players (but with any game mode). A nice feature of the strategy is that the players don't even look which cards are affected by hints, a hint is purely to give a number from 0 to 8 to the other players.
Currently the strategy is allowed to give clues pointing to zero cards in someone's hand. This is allowed in some variants of Hanabi but disallowed in others. But because I only need 9 possible clues, it should be easy to adapt the strategy so that it only gives clues which actually point to something.

To simplify the code, I wanted to allow players to "think out of their turn," i.e. when I give a clue, I want that every player interprets what that clue means at that moment. To do this, the `play()` function of `HatPlayer` now calls commands (like `think_out_of_turn`) of the other players. To make this possible, I added the `PlayerRecord` variable to the `Round` class, which is a list containing all the player objects. 

The code is Python2 and Python3 compatible.
