### PR TITLE
Remove hand-rolled implementation of max and min

### DIFF
--- a/bot_utils.py
+++ b/bot_utils.py
@@ -43,43 +43,14 @@ def possible_hints(card):
     name = card['name']
     return name[0] + VANILLA_SUITS if RAINBOW_SUIT in name else name
 
-def find_max(f, lst):
-    """Returns sublist of lst with all members x where f(x) is maximal"""
-    if len(lst) <= 1: # a little optimization if calling f is expensive
-        return lst
-    l = []
-    for x in lst:
-        value = f(x)
-        if 'highest' not in locals() or value > highest:
-            highest = value
-            l = [x]
-        elif value == highest:
-            l.append(x)
-    return l
-
-def find_min(f, lst):
-    """Analogous to find_max"""
-    if len(lst) <= 1:
-        return lst
-    l = []
-    for x in lst:
-        value = f(x)
-        if 'lowest' not in locals() or value < lowest:
-            lowest = value
-            l = [x]
-        elif value == lowest:
-            l.append(x)
-    return l
-
 def find_highest(cards):
-    """Returns list of cards with highest value in a list;
+    """Returns card with highest number value in a list;
     call only on visible cards!"""
-    return find_max (lambda x: int(x['name'][0]), cards)
+    return max(cards, key=lambda card: int(card['name'][0]))
 
 def find_lowest(cards):
     """Analogous to find_highest"""
-    return find_min (lambda x: int(x['name'][0]), cards)
-
+    return min(cards, key=lambda card: int(card['name'][0]))
 
 def deduce_plays(cards, progress, suits):
     """Return a list of plays (subset of input); fine to call on own hand."""

--- a/players/cheating_player.py
+++ b/players/cheating_player.py
@@ -67,18 +67,19 @@ class CheatingPlayer(AIPlayer):
             return 1, random.choice(discardCards)
         discardCards = get_visible_cards(cards, get_all_visible_cards(player,r))
         if discardCards: # discard a card which you can see (lowest first)
-            discardCards = find_lowest(discardCards)
-            return 2, random.choice(discardCards)
+            random.shuffle(discardCards)
+            return 2, find_lowest(discardCards)
         # note: we never reach this part of the code if there is a 1 in the
         # hand of player
         discardCards = get_nonvisible_cards(cards, r.discardpile)
         discardCards = list(filter(lambda x: x['name'][0] != '5', discardCards))
         if discardCards: # discard a card which is not unsafe to discard
-            discardCards = find_highest(discardCards)
-            card = random.choice(discardCards)
+            random.shuffle(discardCards)
+            card = find_highest(discardCards)
             return 50 - 10 * int(card['name'][0]), card
-        discardCards = find_highest(cards)
-        card = random.choice(discardCards)
+        cards_copy = list(cards)
+        random.shuffle(cards_copy)
+        card = find_highest(cards_copy)
         return 600 - 100 * int(card['name'][0]), card
 
     def play(self, r):
@@ -96,8 +97,8 @@ class CheatingPlayer(AIPlayer):
 
         playableCards = get_plays(cards, progress)
         if playableCards: # Play a card, if possible (lowest value first)
-            wanttoplay = find_lowest(playableCards)
-            return 'play', random.choice(wanttoplay)
+            random.shuffle(playableCards)
+            return 'play', find_lowest(playableCards)
 
         if r.hints == 8: # Hint if you are at maximum hints
             return 'hint', (nextplayer, '5')

--- a/players/hat_player.py
+++ b/players/hat_player.py
@@ -123,7 +123,7 @@ class HatPlayer(AIPlayer):
         playableCards = list(filter(lambda x: x['name'] not in dont_play,\
                                     get_plays(cards, progress)))
         if playableCards:
-            wanttoplay = find_lowest(playableCards)[0]
+            wanttoplay = find_lowest(playableCards)
             return cards.index(wanttoplay)
         # Do we have plenty of clues?
         if hints > 5:
@@ -210,8 +210,8 @@ class HatPlayer(AIPlayer):
         discardCards = list(filter(lambda x: x['name'][0] != '5', discardCards))
         assert all(map(lambda x: x['name'][0] != '1', discardCards))
         if discardCards: # discard a card which is not unsafe to discard
-            discardCards = find_highest(discardCards)
-            return cards.index(discardCards[0]) + 4
+            discardCard = find_highest(discardCards)
+            return cards.index(discardCard) + 4
         return 0
 
 


### PR DESCRIPTION
Minor changes to hat and cheater to use built-in max and min functions.
This changes the find_highest and find_lowest functions to only return
a single value.  In the case of hat player, only the first value was
ever being used, so the exact behavior is maintained, as established
with /test/regression.py.  For cheater, the random selection is done
differently now, but the output passes manual inspection.
