### PR TITLE
Allow people with run hanabi without numpy, and other cleanup

### DIFF
--- a/players/__init__.py
+++ b/players/__init__.py
@@ -9,7 +9,11 @@ import inspect
 from hanabi_classes import AIPlayer
 
 for loader, name, is_pkg in pkgutil.walk_packages(__path__):
-    module = loader.find_module(name).load_module(name)
+    try: # only fail later if desired players can't be loaded *cough* numpy
+      module = loader.find_module(name).load_module(name)
+    except ImportError as err:
+      print("Failed to import " + name + " due to error: " + str(err))
+      continue
 
     for name, value in inspect.getmembers(module):
         if name.startswith('__'):

--- a/players/cheating_idiot_player.py
+++ b/players/cheating_idiot_player.py
@@ -14,7 +14,7 @@ class CheatingIdiotPlayer(AIPlayer):
         return 'idiot'
 
     def __init__(self, *args):
-    	"""Can be overridden to perform initialization, but must call super"""
+        """Can be overridden to perform initialization, but must call super"""
         super(CheatingIdiotPlayer, self).__init__(*args)
 
     def play(self, r):
@@ -28,5 +28,5 @@ class CheatingIdiotPlayer(AIPlayer):
             return 'play', random.choice(playableCards)
 
     def end_game_logging(self):
-    	"""Can be overridden to perform logging at the end of the game"""
-    	pass
+        """Can be overridden to perform logging at the end of the game"""
+        pass

--- a/players/hat_player.py
+++ b/players/hat_player.py
@@ -120,8 +120,8 @@ class HatPlayer(AIPlayer):
         # this is never called on a player's own hand
         assert self != r.PlayerRecord[me]
         # Do I want to play?
-        playableCards = list(filter(lambda x: x['name'] not in dont_play,\
-                                    get_plays(cards, progress)))
+        playableCards = [card for card in get_plays(cards, progress)
+                if card['name'] not in dont_play]
         if playableCards:
             wanttoplay = find_lowest(playableCards)
             return cards.index(wanttoplay)
@@ -152,8 +152,8 @@ class HatPlayer(AIPlayer):
         # a future person to discard, do that.
         if x < 4:
             if self.min_futurehints <= 0 and cards[x]['name'][0] != '5':
-                playablefives = list(filter(lambda x: x['name'][0] == '5',\
-                                            get_plays(cards, progress)))
+                playablefives = [card for card in get_plays(cards, progress)
+                        if card['name'][0] == '5']
                 if playablefives:
                     if r.verbose:
                         print('play a 5 instead')
@@ -197,7 +197,7 @@ class HatPlayer(AIPlayer):
         discardCards = get_duplicate_cards(cards)
         if discardCards: # discard a card which occurs twice in your hand
             return cards.index(discardCards[0]) + 4
-        discardCards = list(filter(lambda x: x['name'] in dont_play, cards))
+        discardCards = [card for card in cards if card['name'] in dont_play]
         if discardCards: # discard a card which will be played by this clue
             return cards.index(discardCards[0]) + 4
         # Otherwise clue
@@ -207,7 +207,7 @@ class HatPlayer(AIPlayer):
         """Find the least bad card to discard"""
         discardCards = get_nonvisible_cards(cards, \
                                         r.discardpile + self.futurediscarded)
-        discardCards = list(filter(lambda x: x['name'][0] != '5', discardCards))
+        discardCards = [card for card in discardCards if card['name'][0] != '5']
         assert all(map(lambda x: x['name'][0] != '1', discardCards))
         if discardCards: # discard a card which is not unsafe to discard
             discardCard = find_highest(discardCards)

--- a/players/heuristics_player.py
+++ b/players/heuristics_player.py
@@ -91,7 +91,7 @@ class HeuristicsUtils(object):
             if card_name in useful_cardnames:
                 overallProbability += probability
         
-        print overallProbability
+        print(overallProbability)
 
     def get_probability_playable(self, card, location):
         odds = self.get_probability_playable_true(card)


### PR DESCRIPTION
If numpy is missing, just fail to load encoding players, instead of failing.  Let hanabi_wrapper fail if the encoding players are requested.  Also slight code cleanup in hat and heuristic players.
