### PR TITLE
Fix Encoding and General Encoding players

### DIFF
--- a/hanabi_classes.py
+++ b/hanabi_classes.py
@@ -183,7 +183,6 @@ class Round(object):
         with self.PolicedHand(self.isPoliced, hand):
             play = playType, playValue = p.play(self)
         self.playHistory.append(play)
-        self.HandHistory.append(self.h[:])
         self.progressHistory.append(dict.copy(self.progress))
 
         verboseHandAtStart = ' '.join([card['name'] for card in hand.cards])

--- a/players/encoding_player.py
+++ b/players/encoding_player.py
@@ -8,9 +8,7 @@ Created on Sun Apr 17 15:11:03 2016
 from copy import deepcopy as c
 import itertools as it
 import numpy as np
-#import sys
-#import random
-#
+
 from hanabi_classes import AIPlayer
 
 # This AI is designed to implement an information encoding algorithm
@@ -60,11 +58,11 @@ class EncodingPlayer(AIPlayer):
         self.CodeList.append('0S_all__1S_all')
     
     def play(self, r):
+        r.HandHistory.append(c(r.h))
         nPriorTurns = len(r.playHistory)
         if r.suits != 'rygbw':
             raise NameError('Encoding AI requires vanilla suits\n')
         for i in r.NameRecord:
-            print(i)
             if i[:-1] != 'Encoder':
                 raise NameError('Encoding AI must only play with other encoders')
         if r.nPlayers != 5:

--- a/players/general_encoding_player.py
+++ b/players/general_encoding_player.py
@@ -17,7 +17,8 @@ class GeneralEncodingPlayer(AIPlayer):
     def get_name(cls):
         return 'gencoder'
 
-    def __init__(self):
+    def __init__(self, me, logger, verbosity):
+        super(GeneralEncodingPlayer, self).__init__(me, logger, verbosity)
         # This boolean is for replicate runs. Certain initialization routines
         # only need to be performed once, and can be carried over across
         # multiple games. However since the initialization depends on the game
@@ -26,6 +27,7 @@ class GeneralEncodingPlayer(AIPlayer):
         self.Initialized = False                  
  
     def play(self,r):
+        r.HandHistory.append(c(r.h))
         nPriorTurns = len(r.playHistory)
         if nPriorTurns <= r.nPlayers - 1:
             self.Startup(r)


### PR DESCRIPTION
My change to remove deepcopy broke the Encoding player.  I didn't notice
because I didn't look closely enough, and the General Encoding player
was already broken, and thus didn't change.  The General Encoding player
needed an update to **init** from the AIPlayer refactoring.  Both
encoding players mutate the attributes of the hand in HandHistory, so
I'm having them update that attribute of the round.
Maybe I'll look into cleaning them up further.  Probably not.
