### PR TITLE
greatly improve hat player

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ __pycache__
 venv/
 test/tmp/
 test/seed.txt
+games.log
+log.json

--- a/bot_utils.py
+++ b/bot_utils.py
@@ -150,6 +150,10 @@ def count_unplayed_playable_cards(r, progress):
                 break
     return n
 
+def get_all_playable_cardnames(r):
+    """Gets all cards that can be played now"""
+    return [str(r.progress[suit] + 1) + suit for suit in r.suits if r.progress[suit] < 5]
+
 def get_all_useful_cardnames(r):
     """Gets all cards that could be playable in future"""
     l = []

--- a/bot_utils.py
+++ b/bot_utils.py
@@ -199,9 +199,15 @@ def inverse_card_set(cardset, r):
 def is_critical(cardname, r):
     """Tests whether card is not played and there is no other non-discarded card with the same name
     Does not check whether all copies of a lower rank are already discarded"""
-    if r.progress[cardname[1]] >= int(cardname[0]):
+    return is_critical_aux(cardname, r.progress, r.discardpile)
+
+def is_critical_aux(cardname, progress, discardpile):
+    """Same as is_critical, but takes the progress and discardpile as arguments. Useful if you want to check
+    whether something was critical at another time"""
+    if progress[cardname[1]] >= int(cardname[0]):
         return False
-    return r.discardpile.count(cardname) + 1 == SUIT_CONTENTS.count(cardname[0])
+    return discardpile.count(cardname) + 1 == SUIT_CONTENTS.count(cardname[0])
+
 
 def find_all_lowest(l, f):
     """Find all elements x in l where f(x) is minimal"""

--- a/bot_utils.py
+++ b/bot_utils.py
@@ -190,3 +190,20 @@ def inverse_card_set(cardset, r):
             else:
                 inverse_set.append(newCard)
     return inverse_set
+
+def is_critical(cardname, r):
+    """Tests whether card is not played and there is no other non-discarded card with the same name
+    Does not check whether all copies of a lower rank are already discarded"""
+    if r.progress[cardname[1]] >= int(cardname[0]):
+        return False
+    return r.discardpile.count(cardname) + 1 == SUIT_CONTENTS.count(cardname[0])
+
+def find_all_lowest(l, f):
+    """Find all elements x in l where f(x) is minimal"""
+    minvalue = min([f(x) for x in l])
+    return [x for x in l if f(x) == minvalue]
+
+def find_all_highest(l, f):
+    """Find all elements x in l where f(x) is maximal"""
+    maxvalue = max([f(x) for x in l])
+    return [x for x in l if f(x) == maxvalue]

--- a/bot_utils.py
+++ b/bot_utils.py
@@ -166,7 +166,7 @@ def get_all_useful_cardnames(r):
 
 def can_see_all_useful_cards(me, r):
     """Returns whether the player can see at least one copy of each card which is still playable"""
-    visible_cards = map(lambda x: x['name'], get_all_visible_cards(me, r))
+    visible_cards = names(get_all_visible_cards(me, r))
     useful_cards = get_all_useful_cardnames(r)
     return is_subset(useful_cards, visible_cards)
 

--- a/doc_hat_player.md
+++ b/doc_hat_player.md
@@ -239,6 +239,8 @@ corresponding clue.
 
 ## Clue encoding
 
+[Update February 2019: `hat_player` now doesn't give empty clues anymore.]
+
 There are two variants of Hanabi. One variant allows you to give a clue pointing to 0 cards ("You
 have no blue cards in your hand") while the other disallows it. The first variant is slightly
 easier, especially for a strategy using a coding function for the clues, because in that variant

--- a/hanabi_classes.py
+++ b/hanabi_classes.py
@@ -226,6 +226,7 @@ class Round(object):
                     if value == '5':
                         self.hints = min(self.hints + 1, N_HINTS)
                 else: # Illegal play
+                    card['misplayed'] = True
                     self.lightning += 1
                     desc += ' (DOH!)'
 
@@ -250,6 +251,7 @@ class Round(object):
           known (bool): whether card can be deduced solely from public info
           cardNo (int): unique number of the card
           position (int): the position from which the card was played or discarded (0-4). Equals -1 if still in hand
+          misplayed (bool): set to true if this card was misplayed
         seat (int): Player ID number (starting player is 0).
         """
 
@@ -273,7 +275,8 @@ class Round(object):
                                 'known'    : False,
                                 'sec_name' : newCard,
                                 'cardNo'   : cardNo,
-                                'position' : -1 })
+                                'position' : -1,
+                                'misplayed': False })
 
         def drop(self, card):
             """Discard a card from the hand."""

--- a/hanabi_classes.py
+++ b/hanabi_classes.py
@@ -188,6 +188,8 @@ class Round(object):
             assert self.hints != 0
             targetPlayer, info = playValue
             assert targetPlayer != self.whoseTurn # Cannot hint self.
+            assert info in self.suits or info in SUIT_CONTENTS
+            assert info != '?'
             targetHand = self.h[targetPlayer]
             for card in targetHand.cards:
                 suit = card['name'][1]

--- a/hanabi_classes.py
+++ b/hanabi_classes.py
@@ -127,13 +127,15 @@ class Round(object):
 
         random.shuffle(deck)
         self.deck = deck
+        self.startingDeck = deck[:]
+        self.startingDeckSize = len(deck)
 
         handSize = 4
         if self.nPlayers < 4:
             handSize += 1
         for i in range(self.nPlayers): # Deal cards to all players.
             for j in range(handSize):
-                self.h[i].add(self.draw(), self.turnNumber - handSize + j)
+                self.h[i].add(self.draw(), self.turnNumber - handSize + j, self.startingDeckSize-len(self.deck)-1)
             if self.verbose:
                 self.h[i].show(self.zazz[0], self.logger)
                 self.zazz[0] = ' ' * len(self.zazz[0])
@@ -150,7 +152,7 @@ class Round(object):
         self.DropIndRecord.append(ReplacedIndex)
         self.discardpile.append(card['name'])
         if self.deck != []:
-            hand.add(self.draw(), self.turnNumber)
+            hand.add(self.draw(), self.turnNumber, self.startingDeckSize-len(self.deck)-1)
             return True # There was still a card to draw.
         return False
 
@@ -257,14 +259,15 @@ class Round(object):
             out = [card['name'] for card in self.cards]
             logger.info(zazz + ' ' + self.name + ': ' + ' '.join(out))
 
-        def add(self, newCard, turnNumber):
+        def add(self, newCard, turnNumber, cardNo):
             """Add a card to the hand."""
             self.cards.append({ 'name'     : newCard,
                                 'time'     : turnNumber,
                                 'direct'   : [],
                                 'indirect' : [],
                                 'known'    : False,
-                                'sec_name' : newCard})
+                                'sec_name' : newCard,
+                                'cardNo'   : cardNo })
 
         def drop(self, card):
             """Discard a card from the hand."""

--- a/hanabi_classes.py
+++ b/hanabi_classes.py
@@ -148,6 +148,7 @@ class Round(object):
         """Drop the card, draw a new one, and update public info."""
         if not card['known']:
             self.cardsLeft.remove(card['name'])
+        card['position'] = hand.cards.index(card)
         ReplacedIndex = hand.drop(card)
         self.DropIndRecord.append(ReplacedIndex)
         self.discardpile.append(card['name'])
@@ -245,6 +246,8 @@ class Round(object):
             a color or a number; chronological; duplicates allowed
           indirect (list of char): same as direct but info does not match card
           known (bool): whether card can be deduced solely from public info
+          cardNo (int): unique number of the card
+          position (int): the position from which the card was played or discarded (0-4). Equals -1 if still in hand
         seat (int): Player ID number (starting player is 0).
         """
 
@@ -267,7 +270,8 @@ class Round(object):
                                 'indirect' : [],
                                 'known'    : False,
                                 'sec_name' : newCard,
-                                'cardNo'   : cardNo })
+                                'cardNo'   : cardNo,
+                                'position' : -1 })
 
         def drop(self, card):
             """Discard a card from the hand."""

--- a/hanabi_classes.py
+++ b/hanabi_classes.py
@@ -69,7 +69,7 @@ class Round(object):
     discardpile: list of (names of) cards which are discarded
     """
 
-    def __init__(self, gameType, players, names, verbosity, isPoliced):
+    def __init__(self, gameType, players, names, verbosity, isPoliced, stats):
         """Instantiate a Round and its Hand sub-objects."""
         self.gameType  = gameType
         self.suits = VANILLA_SUITS
@@ -96,6 +96,7 @@ class Round(object):
         self.log = (verbosity == 'log')
         self.zazz = ['[HANDS]', '[PLAYS]']
         self.isPoliced = isPoliced
+        self.stats = stats
 
         self.logger = logging.getLogger('game_log')
 

--- a/hanabi_classes.py
+++ b/hanabi_classes.py
@@ -69,7 +69,7 @@ class Round(object):
     discardpile: list of (names of) cards which are discarded
     """
 
-    def __init__(self, gameType, players, names, verbosity, isPoliced, stats):
+    def __init__(self, gameType, players, names, verbosity, isPoliced, debug):
         """Instantiate a Round and its Hand sub-objects."""
         self.gameType  = gameType
         self.suits = VANILLA_SUITS
@@ -96,7 +96,7 @@ class Round(object):
         self.log = (verbosity == 'log')
         self.zazz = ['[HANDS]', '[PLAYS]']
         self.isPoliced = isPoliced
-        self.stats = stats
+        self.debug = debug
 
         self.logger = logging.getLogger('game_log')
 

--- a/hanabi_wrapper.py
+++ b/hanabi_wrapper.py
@@ -112,21 +112,22 @@ if args.verbosity == 'log':
 if args.seed >= 0:
     random.seed(args.seed)
 
-stats = {} # a dictionary players can write into which will be printed in the end. Useful for collecting statistics
-# if you set r.stats['stop'] = 0, then the log of that game will be appended to log.json, and no new game will be started
+debug = {} # a dictionary players can write into which will be printed in the end. Useful for collecting statistics
+# if you set r.debug['stop'] = 0, then the log of that game will be appended to log.json, and no new game will be started
 
 if args.output:
   os.remove('log.json')
 # Play rounds.
 scores = []
 for i in range(args.n_rounds):
-    if 'stop' in stats:
+    if 'stop' in debug:
         logger.info("Games interrupted by player after round " + str(i) + "!")
+        args.n_rounds = i
         break
     if args.verbosity in ('verbose', 'log'):
         logger.info('\n' + 'ROUND {}:'.format(i))
     score = play_one_round(args.game_type, players, names, args.verbosity,
-                           args.loss_score, args.police, args.output, stats)
+                           args.loss_score, args.police, args.output, debug)
     scores.append(score)
     if args.verbosity != 'silent':
         logger.info('Score: ' + str(score))
@@ -150,5 +151,5 @@ if len(scores) > 1: # Only print stats if there were multiple rounds.
 elif args.verbosity == 'silent': # Still print score for silent single round
     logger.info('Score: ' + str(scores[0]))
 
-stats = {k:v for k, v in stats.items() if v != 0}
-if stats: print(stats)
+debug = {k:v for k, v in debug.items() if v != 0}
+if debug: print(debug)

--- a/hanabi_wrapper.py
+++ b/hanabi_wrapper.py
@@ -12,7 +12,7 @@ Command-line arguments (see usage):
   loss_score: Whether to award points after a game is lost
 """
 
-import sys, argparse, logging, random
+import sys, argparse, logging, random, os
 from time import gmtime, strftime
 from math import sqrt
 from play_hanabi import play_one_round, player_end_game_logging
@@ -112,6 +112,8 @@ if args.verbosity == 'log':
 if args.seed >= 0:
     random.seed(args.seed)
 
+if args.output:
+  os.remove('log.json')
 # Play rounds.
 scores = []
 for i in range(args.n_rounds):
@@ -123,7 +125,6 @@ for i in range(args.n_rounds):
     if args.verbosity != 'silent':
         logger.info('Score: ' + str(score))
     player_end_game_logging(players)
-    args.output = False # we don't have to log multiple games
 
 # Print average scores.
 if args.verbosity != 'silent':

--- a/hanabi_wrapper.py
+++ b/hanabi_wrapper.py
@@ -117,6 +117,10 @@ debug = {} # a dictionary players can write into which will be printed in the en
 
 if args.output and os.path.exists('log.json'):
   os.remove('log.json')
+  for i in range(len(players)):
+    for c in range(10 * (5 if args.game_type == 'vanilla' else 6)):
+        debug[('note', i, c)] = ''
+
 # Play rounds.
 scores = []
 for i in range(args.n_rounds):
@@ -151,5 +155,5 @@ if len(scores) > 1: # Only print stats if there were multiple rounds.
 elif args.verbosity == 'silent': # Still print score for silent single round
     logger.info('Score: ' + str(scores[0]))
 
-debug = {k:v for k, v in debug.items() if v != 0}
+debug = {k:v for k, v in debug.items() if v is not 0 and v is not ''}
 if debug: print("debug info:",debug)

--- a/hanabi_wrapper.py
+++ b/hanabi_wrapper.py
@@ -152,4 +152,4 @@ elif args.verbosity == 'silent': # Still print score for silent single round
     logger.info('Score: ' + str(scores[0]))
 
 debug = {k:v for k, v in debug.items() if v != 0}
-if debug: print(debug)
+if debug: print("debug info:",debug)

--- a/hanabi_wrapper.py
+++ b/hanabi_wrapper.py
@@ -41,6 +41,9 @@ parser.add_argument('-s', '--seed', default=-1,
 parser.add_argument('-p', '--police',
   dest='police', action='store_true', help='Turns on the police to catch cheaters')
 parser.set_defaults(police=False)
+parser.add_argument('-o', '--output',
+  dest='output', action='store_true', help='Output a JSON file of the game in log.json')
+parser.set_defaults(output=False)
 
 args = parser.parse_args()
 
@@ -115,7 +118,7 @@ for i in range(args.n_rounds):
     if args.verbosity in ('verbose', 'log'):
         logger.info('\n' + 'ROUND {}:'.format(i))
     score = play_one_round(args.game_type, players, names, args.verbosity,
-                           args.loss_score, args.police)
+                           args.loss_score, args.police, args.output)
     scores.append(score)
     if args.verbosity != 'silent':
         logger.info('Score: ' + str(score))

--- a/hanabi_wrapper.py
+++ b/hanabi_wrapper.py
@@ -112,6 +112,8 @@ if args.verbosity == 'log':
 if args.seed >= 0:
     random.seed(args.seed)
 
+stats = {} # a dictionary players can write into which will be printed in the end. Useful for collecting statistics
+
 if args.output:
   os.remove('log.json')
 # Play rounds.
@@ -120,7 +122,7 @@ for i in range(args.n_rounds):
     if args.verbosity in ('verbose', 'log'):
         logger.info('\n' + 'ROUND {}:'.format(i))
     score = play_one_round(args.game_type, players, names, args.verbosity,
-                           args.loss_score, args.police, args.output)
+                           args.loss_score, args.police, args.output, stats)
     scores.append(score)
     if args.verbosity != 'silent':
         logger.info('Score: ' + str(score))
@@ -143,3 +145,6 @@ if len(scores) > 1: # Only print stats if there were multiple rounds.
                 .format(100*perfect_games, 100*std_perfect_games))
 elif args.verbosity == 'silent': # Still print score for silent single round
     logger.info('Score: ' + str(scores[0]))
+
+stats = {k:v for k, v in stats.items() if v != 0}
+if stats: print(stats)

--- a/hanabi_wrapper.py
+++ b/hanabi_wrapper.py
@@ -115,7 +115,7 @@ if args.seed >= 0:
 debug = {} # a dictionary players can write into which will be printed in the end. Useful for collecting statistics
 # if you set r.debug['stop'] = 0, then the log of that game will be appended to log.json, and no new game will be started
 
-if args.output:
+if args.output and os.path.exists('log.json'):
   os.remove('log.json')
 # Play rounds.
 scores = []

--- a/hanabi_wrapper.py
+++ b/hanabi_wrapper.py
@@ -123,6 +123,7 @@ for i in range(args.n_rounds):
     if args.verbosity != 'silent':
         logger.info('Score: ' + str(score))
     player_end_game_logging(players)
+    args.output = False # we don't have to log multiple games
 
 # Print average scores.
 if args.verbosity != 'silent':

--- a/hanabi_wrapper.py
+++ b/hanabi_wrapper.py
@@ -113,12 +113,16 @@ if args.seed >= 0:
     random.seed(args.seed)
 
 stats = {} # a dictionary players can write into which will be printed in the end. Useful for collecting statistics
+# if you set r.stats['stop'] = 0, then the log of that game will be appended to log.json, and no new game will be started
 
 if args.output:
   os.remove('log.json')
 # Play rounds.
 scores = []
 for i in range(args.n_rounds):
+    if 'stop' in stats:
+        logger.info("Games interrupted by player after round " + str(i) + "!")
+        break
     if args.verbosity in ('verbose', 'log'):
         logger.info('\n' + 'ROUND {}:'.format(i))
     score = play_one_round(args.game_type, players, names, args.verbosity,

--- a/play_hanabi.py
+++ b/play_hanabi.py
@@ -61,8 +61,9 @@ def play_one_round(gameType, players, names, verbosity, lossScore, isPoliced,wri
         if gameType == 'purple': variant = "Six Suits"
         if gameType == 'vanilla': variant = "No Variant"
         output = { "actions": actions, "deck": startDeck, "notes": notes, "players": players, "variant": variant }
-        with io.open('log.json', 'w', encoding='utf-8') as f:
+        with io.open('log.json', 'a', encoding='utf-8') as f:
             f.write(json.dumps(output, ensure_ascii=False))
+            f.write('\n\n')
 
     if r.lightning == N_LIGHTNING and lossScore == 'zero':
         return 0 # Award no points for a loss

--- a/play_hanabi.py
+++ b/play_hanabi.py
@@ -48,7 +48,7 @@ def play_one_round(gameType, players, names, verbosity, lossScore, isPoliced,wri
         r.get_play(players[r.whoseTurn]) # Play one turn.
 
     if writeOutput or 'stop' in debug:
-        if not writeOutput: os.remove('log.json')
+        if not writeOutput and os.path.exists('log.json'): os.remove('log.json')
         actions = list(map(lambda action: to_json(r, action), r.playHistory))
         handSize = 4
         if r.nPlayers < 4: handSize += 1

--- a/play_hanabi.py
+++ b/play_hanabi.py
@@ -26,9 +26,9 @@ def to_json (r, action):
         dic = {"type":actionType, "target":target}
     return dic
 
-def play_one_round(gameType, players, names, verbosity, lossScore, isPoliced,writeOutput, stats):
+def play_one_round(gameType, players, names, verbosity, lossScore, isPoliced,writeOutput, debug):
     """Play a full round and return the score (int)."""
-    r = Round(gameType, players, names, verbosity, isPoliced, stats) # Instance of a single Hanabi round
+    r = Round(gameType, players, names, verbosity, isPoliced, debug) # Instance of a single Hanabi round
     r.generate_deck_and_deal_hands()
 
     while r.gameOverTimer != 0:
@@ -47,7 +47,7 @@ def play_one_round(gameType, players, names, verbosity, lossScore, isPoliced,wri
 
         r.get_play(players[r.whoseTurn]) # Play one turn.
 
-    if writeOutput or 'stop' in stats:
+    if writeOutput or 'stop' in debug:
         if not writeOutput: os.remove('log.json')
         actions = list(map(lambda action: to_json(r, action), r.playHistory))
         handSize = 4

--- a/play_hanabi.py
+++ b/play_hanabi.py
@@ -26,9 +26,9 @@ def to_json (r, action):
         dic = {"type":actionType, "target":target}
     return dic
 
-def play_one_round(gameType, players, names, verbosity, lossScore, isPoliced,writeOutput):
+def play_one_round(gameType, players, names, verbosity, lossScore, isPoliced,writeOutput, stats):
     """Play a full round and return the score (int)."""
-    r = Round(gameType, players, names, verbosity, isPoliced) # Instance of a single Hanabi round
+    r = Round(gameType, players, names, verbosity, isPoliced, stats) # Instance of a single Hanabi round
     r.generate_deck_and_deal_hands()
 
     while r.gameOverTimer != 0:

--- a/play_hanabi.py
+++ b/play_hanabi.py
@@ -26,8 +26,9 @@ def to_json (r, action):
         dic = {"type":actionType, "target":target}
     return dic
 
-def play_one_round(gameType, players, names, verbosity, lossScore, isPoliced,writeOutput, debug):
+def play_one_round(gameType, players, names, verbosity, lossScore, isPoliced, writeOutput, debug):
     """Play a full round and return the score (int)."""
+
     r = Round(gameType, players, names, verbosity, isPoliced, debug) # Instance of a single Hanabi round
     r.generate_deck_and_deal_hands()
 
@@ -53,10 +54,7 @@ def play_one_round(gameType, players, names, verbosity, lossScore, isPoliced,wri
         handSize = 4
         if r.nPlayers < 4: handSize += 1
         startDeck = list(map(lambda card: {"rank": int(card[0]), "suit": r.suits.index(card[1])}, r.startingDeck))
-        # we need to reverse the starting hands
-        # startingHands = list(map(lambda i: startDeck[slice(i*handSize,(i+1)*handSize)][::-1], range(r.nPlayers)))
-        # startDeck = [item for x in startingHands for item in x] + startDeck[r.nPlayers*handSize:] # reverse starting hands
-        notes = [[]] * len(names)
+        notes = [[debug[('note', i, c)] for c in range(10 * (5 if gameType == 'vanilla' else 6))] for i in range(r.nPlayers)]
         players = names
         if gameType == 'rainbow': variant = "Rainbow (6 Suits)"
         if gameType == 'purple': variant = "Six Suits"
@@ -65,6 +63,10 @@ def play_one_round(gameType, players, names, verbosity, lossScore, isPoliced,wri
         with io.open('log.json', 'a', encoding='utf-8') as f:
             f.write(json.dumps(output, ensure_ascii=False))
             f.write('\n\n')
+        for i in range(len(players)):
+            for c in range(10 * (5 if gameType == 'vanilla' else 6)):
+                debug[('note', i, c)] = ''
+
 
     if r.lightning == N_LIGHTNING and lossScore == 'zero':
         return 0 # Award no points for a loss

--- a/play_hanabi.py
+++ b/play_hanabi.py
@@ -5,7 +5,7 @@ round can be played.  Low-level details, along with thorough documentation, are
 in another module (hanabi_classes).
 """
 
-import json, io
+import json, io, os
 from hanabi_classes import *
 
 def to_json (r, action):
@@ -47,7 +47,8 @@ def play_one_round(gameType, players, names, verbosity, lossScore, isPoliced,wri
 
         r.get_play(players[r.whoseTurn]) # Play one turn.
 
-    if writeOutput:
+    if writeOutput or 'stop' in stats:
+        if not writeOutput: os.remove('log.json')
         actions = list(map(lambda action: to_json(r, action), r.playHistory))
         handSize = 4
         if r.nPlayers < 4: handSize += 1

--- a/play_hanabi.py
+++ b/play_hanabi.py
@@ -5,9 +5,28 @@ round can be played.  Low-level details, along with thorough documentation, are
 in another module (hanabi_classes).
 """
 
+import json, io
 from hanabi_classes import *
 
-def play_one_round(gameType, players, names, verbosity, lossScore, isPoliced):
+def to_json (r, action):
+    actionType = ["hint", "play", "discard"].index(action[0])
+    if actionType == 0:
+        target = action[1][0]
+        clue = action[1][1]
+        if clue in r.suits:
+            clueType = 1
+            clueValue = r.suits.index(clue)
+        else:
+            clueType = 0
+            clueValue = int(clue)
+        dic = {"type":actionType, "target":target, "clue":{"type":clueType, "value":clueValue}}
+    else:
+        target=action[1]['cardNo']
+
+        dic = {"type":actionType, "target":target}
+    return dic
+
+def play_one_round(gameType, players, names, verbosity, lossScore, isPoliced,writeOutput):
     """Play a full round and return the score (int)."""
     r = Round(gameType, players, names, verbosity, isPoliced) # Instance of a single Hanabi round
     r.generate_deck_and_deal_hands()
@@ -30,6 +49,23 @@ def play_one_round(gameType, players, names, verbosity, lossScore, isPoliced):
                 break    # ... unless user wants the full score.
 
         r.get_play(players[r.whoseTurn]) # Play one turn.
+
+    if writeOutput:
+        actions = list(map(lambda action: to_json(r, action), r.playHistory))
+        handSize = 4
+        if r.nPlayers < 4: handSize += 1
+        startDeck = list(map(lambda card: {"rank": int(card[0]), "suit": r.suits.index(card[1])}, r.startingDeck))
+        # we need to reverse the starting hands
+        # startingHands = list(map(lambda i: startDeck[slice(i*handSize,(i+1)*handSize)][::-1], range(r.nPlayers)))
+        # startDeck = [item for x in startingHands for item in x] + startDeck[r.nPlayers*handSize:] # reverse starting hands
+        notes = [[]] * len(names)
+        players = names
+        if gameType == 'rainbow': variant = "Rainbow (6 Suits)"
+        if gameType == 'purple': variant = "Six Suits"
+        if gameType == 'vanilla': variant = "No Variant"
+        output = { "actions": actions, "deck": startDeck, "notes": notes, "players": players, "variant": variant }
+        with io.open('log.json', 'w', encoding='utf-8') as f:
+            f.write(json.dumps(output, ensure_ascii=False))
 
     return sum(r.progress.values()) # Final score
 

--- a/play_hanabi.py
+++ b/play_hanabi.py
@@ -43,10 +43,7 @@ def play_one_round(gameType, players, names, verbosity, lossScore, isPoliced,wri
             break # Resignation for debug purposes
 
         if r.lightning == N_LIGHTNING:
-            if lossScore == 'zero':
-                return 0 # Award no points for a loss...
-            elif lossScore == 'full':
-                break    # ... unless user wants the full score.
+            break # The game ends by having three strikes
 
         r.get_play(players[r.whoseTurn]) # Play one turn.
 
@@ -67,6 +64,8 @@ def play_one_round(gameType, players, names, verbosity, lossScore, isPoliced,wri
         with io.open('log.json', 'w', encoding='utf-8') as f:
             f.write(json.dumps(output, ensure_ascii=False))
 
+    if r.lightning == N_LIGHTNING and lossScore == 'zero':
+        return 0 # Award no points for a loss
     return sum(r.progress.values()) # Final score
 
 def player_end_game_logging(players):

--- a/players/cheating_player.py
+++ b/players/cheating_player.py
@@ -5,10 +5,10 @@ table gives the approximate percentages of this strategy reaching maximum score.
 
 Players | % (5 suits) | % (6 suits)
 --------+-------------+-------------
-   2    |    94.5     |     91.0
-   3    |    98.6     |     98.6
-   4    |    98.3     |     98.5
-   5    |    97.2     |     98.0
+   2    |    94.9     |     90.6
+   3    |    98.5     |     98.5
+   4    |    98.2     |     98.2
+   5    |    97.0     |     97.8
 
 Possible improvements (probably this doesn't actually increase the win percentage):
 - When playing a card, prefer one that allows other players to follow up in the

--- a/players/hat_player.py
+++ b/players/hat_player.py
@@ -6,8 +6,8 @@ description of the strategy. The following table gives the approximate
 percentages of this strategy reaching maximum score.
 Players | % (6 suits) | % (5 suits)
 --------+-------------+------------
-   4    |     79      |     84
-   5    |     87      |    79-80
+   4    |     80      |    84.5
+   5    |    86.5     |     80
 
 """
 

--- a/players/hat_player.py
+++ b/players/hat_player.py
@@ -3,13 +3,11 @@
 A strategy for 4 or 5 players which uses "hat guessing" to convey information
 to all other players with a single clue. See doc_hat_player.md for a detailed
 description of the strategy. The following table gives the approximate
-percentages of this strategy reaching maximum score.
-(over 10000 games, rounded to the nearest 0.5%).
-The standard error is 0.3-0.4pp, so it could maybe be a pp off.
-Players | % (5 suits) | % (6 suits)
---------+-------------+------------
-   4    |     90      |     88
-   5    |     87      |     92
+percentages of this strategy reaching maximum score (over 150000 games).
+Players | % (no variant) | % (rainbow)
+--------+----------------+------------
+   4    |      89.7      |   87.8
+   5    |      87.8      |   92.6
 """
 
 #todo:

--- a/players/hat_player.py
+++ b/players/hat_player.py
@@ -422,7 +422,7 @@ class HatPlayer(AIPlayer):
                 # which is relevant to me. This must be up to date all the time
                 r.PlayerRecord[i].last_clued_any_clue = n - 1
                 # do I have a card which can be safely discarded?
-                r.PlayerRecord[i].safe_discad = -1
+                r.PlayerRecord[i].safe_discard = None
         # everyone takes some time to think about the meaning of previously
         # given clues
         for i in range(n):
@@ -438,7 +438,7 @@ class HatPlayer(AIPlayer):
                     if r.hints != 8:
                         return self.execute_action(myaction, r)
                     elif r.verbose:
-                        print("I have to hint at 8 clues, this will screw up the next players' action.")
+                        print("I have to hint at 8 clues, this will screw up the next player's action.")
                 #todo: also discard when you steal the last clue from someone who has to clue
                 #clue if I can get tempo on a unclued card or if at 8 hints
                 if r.hints != 8 and not(all(map(lambda a:a[0] == 'play', self.next_player_actions)) and\
@@ -448,6 +448,7 @@ class HatPlayer(AIPlayer):
                         return self.execute_action(myaction, r)
                     if r.hints <= 1:
                         return self.execute_action(myaction, r)
+                self.safe_discard = r.h[me].cards[myaction[1]]
             if myaction[0] != 'hint' and r.log:
                 print ("clue instead of discard")
         else:
@@ -455,8 +456,13 @@ class HatPlayer(AIPlayer):
         if not r.hints: # I cannot hint without clues
             if r.verbose:
                 print("Cannot clue, because there are no available hints")
-            #todo: discard the card so that the next player does something non-terrible
-            return self.execute_action(('discard', 3), r)
+            x = 3
+            if self.safe_discard is not None and self.safe_discard in r.h[me].cards:
+                x = r.h[me].cards.index(self.safe_discard)
+                if r.verbose:
+                    print("I can discard slot", x, "which I know is trash")
+            #todo: maybe discard the card so that the next player does something non-terrible
+            return self.execute_action(('discard', x), r)
             # a problem in one game was: cluer thinks that a player between them and first_clued is going to discard, which is their standard_play.
             # They decide to clue instead. This causes the number of hints to be 2 smaller than expected, causing the first_clued to be instructed to hint with 0 clues
         # I'm going to hint

--- a/players/hat_player.py
+++ b/players/hat_player.py
@@ -8,9 +8,14 @@ percentages of this strategy reaching maximum score.
 The standard error is 0.3-0.4pp, so it could maybe be a pp off.
 Players | % (5 suits) | % (6 suits)
 --------+-------------+------------
-   4    |     86      |     84
-   5    |     81      |     87.5
+   4    |     90      |     88
+   5    |     87      |     92
 """
+
+#todo:
+# modified_player is wrong
+# to get modified_player, we need to store player_to_card for all players, not just the ones after me
+# to get player_to_card for all players, we add a new variable player_to_card_current
 
 from hanabi_classes import *
 from bot_utils import *
@@ -49,12 +54,14 @@ class HatPlayer(AIPlayer):
         # Every clue consists of a dict with as info:
         # 'value': clue value
         # 'cluer': the player who clued
-        # 'plays': the plays that happened after the clue, stored as a dictionary player:(action, card) (or Null if a hint is given).
+        # 'plays': the plays that happened after the clue, stored as a dictionary player:(action, card) (card is Null if a hint is given).
         self.given_clues = []
 
-    # The following three variables consist of extra information about the 0-th given_clue
+    # The following four variables consist of extra information about the 0-th given_clue
         # what the other players will do with that clue, in turn order
         self.next_player_actions = []
+        # stores items like 0: (n, name) if player 0 is intstructed to play slot n containing card name by the current clue
+        self.player_to_card_current = {}
         # The player who receives the modified action from the current clue
         self.modified_player = -1
         # for every player (other than me or cluer) what their standard action is if they don't have a play
@@ -65,7 +72,7 @@ class HatPlayer(AIPlayer):
         # the players who will still play the cards that need to be played from the already interpreted clues
         # stored as a dictionary card_name: player (e.g. "1y": 0)
         self.card_to_player = {}
-        # stores items like 0: n if player 0 is intstructed to play slot n
+        # stores items like 0: (n, name) if player 0 is intstructed to play slot n containing card name by the previous clue
         self.player_to_card = {}
 
         # do I have a card which can be safely discarded?
@@ -73,17 +80,21 @@ class HatPlayer(AIPlayer):
         # stores the actions between the cluer and the modified_player. Only used when the player is deciding whether to clue
         self.actions_before_modified = []
 
-    def resolve_next_player_actions(self, me, r):
-        """Updates variables using next_player_actions"""
+    def finalize_given_clue(self, me, r):
+        """Updates variables at the end of interpreting a given clue"""
         # is this necessary?
         self.futureprogress = r.progress.copy()
+        # note: this code assumes that self.given_clues is empty if a player is about to give a clue
+        nextcluer = self.given_clues[1]['cluer'] if len(self.given_clues) > 1 else r.whoseTurn
+        if self.given_clues and self.given_clues[0]['cluer'] == nextcluer: # this happens if the next player was the last player to clue and gave me a play clue
+            self.player_to_card = {}
+        else:
+            self.player_to_card = { i:v for i, v in self.player_to_card_current.items() if not self.given_clues or not self.is_between(i, self.given_clues[0]['cluer'], nextcluer)}
+        self.card_to_player = {nm:i for i, (n, nm) in self.player_to_card.items() }
         i = next(me, r)
         for x in self.next_player_actions:
             if x[0] == 'play':
                 name = r.h[i].cards[x[1]]['name']
-                # if either of the next two keys already existed, they already had the value below
-                self.card_to_player[name] = i
-                self.player_to_card[i] = x[1]
                 self.futureprogress[name[1]] = int(name[0])
             i = next(i, r)
         assert i == me or i == self.given_clues[0]['cluer']
@@ -108,17 +119,18 @@ class HatPlayer(AIPlayer):
         """Figure out the initial meaning of a clue.
         This is also used to figure out what to clue, except to modified_player.
         In the latter case, we return the sum of the clue value to all players except modified_player"""
-        assert me not in self.player_to_card
         assert MODIFIEDACTION # this code needs to be adapted if we set this to False
         # find out modified_player
         i = next(cluer, r)
         while i in self.player_to_card: i = next(i, r)
         self.modified_player = i
+        #print(me,"thinks",cluer,"->",self.modified_player,"-",self.player_to_card) # I think this works now, but maybe double check
         # find out expected discards:
         self.expected_discards = {i:self.standard_nonplay(self.recover_hand(i, r), i, self.futureprogress, r) for i in range(r.nPlayers) if i != me and i != cluer}
         # find out what players after me and after modified_player will do
         self.next_player_actions = []
         self.will_be_played = []
+        self.player_to_card_current.clear()
         i = prev(cluer, r)
         value = 0
         while i != me and i != self.modified_player:
@@ -127,7 +139,9 @@ class HatPlayer(AIPlayer):
             #print("player",me,"thinks that player",i,"does",x)
             value += self.action_to_number(x)
             if x[0] == 'play':
-                self.will_be_played.append(r.h[i].cards[x[1]]['name'])
+                cardname = r.h[i].cards[x[1]]['name']
+                self.will_be_played.append(cardname)
+                self.player_to_card_current[i] = x[1], cardname
             i = prev(i, r)
         self.next_player_actions.reverse()
 
@@ -137,7 +151,10 @@ class HatPlayer(AIPlayer):
             while i in self.given_clues[0]['plays']:
                 action, card = self.given_clues[0]['plays'][i]
                 cardname = card['name'] if action[0] != 'hint' else ""
-                value += self.real_action_value(action, cardname, i)
+                action = self.clued_action(action, cardname, i)
+                if action[0] == 'play':
+                    self.player_to_card_current[i] = action[1], cardname
+                value += self.action_to_number(action)
                 i = next(i, r)
             assert i == r.whoseTurn
             # If it's my turn, I now know what my action is
@@ -153,7 +170,8 @@ class HatPlayer(AIPlayer):
         self.actions_before_modified = []
         if self.is_between(i, cluer, self.modified_player) and (i == next(me, r) or i == me):
             while i in self.player_to_card:
-                action = ('play', self.player_to_card[i])
+                self.player_to_card_current[i] = self.player_to_card[i]
+                action = ('play', self.player_to_card[i][0])
                 self.actions_before_modified.append(action)
                 value += self.action_to_number(action)
                 i = next(i, r)
@@ -181,23 +199,23 @@ class HatPlayer(AIPlayer):
                     return myaction
                 if myaction[0] == 'discard':
                     self.safe_discard = r.h[me].cards[myaction[1]]
-            self.resolve_next_player_actions(me, r)
+            self.finalize_given_clue(me, r)
             if len(self.given_clues) == 1 and me == r.whoseTurn:
                 return myaction
             self.given_clues = self.given_clues[1:]
             if not self.given_clues: break
             self.initialize_given_clue(self.given_clues[0]['cluer'], me, r)
 
-    def real_action_value(self, action, cardname, player):
-        """The value of the clue that a player received, given his action"""
+    def clued_action(self, action, cardname, player):
+        """The real action a player received, given his actual action"""
         if (action[0] != 'play' and not (player == self.modified_player and MODIFIEDACTION)) or\
             (action[0] == 'play' and self.futureprogress[cardname[1]] + 1 < int(cardname[0])):
             # the player was instructed to discard, but decided to hint instead, or was instructed by a later clue to play
             if player in self.expected_discards:
-                action = self.expected_discards[player]
-            else:
-                print("I made an unexpected move myself",action,cardname, player, self.given_clues[0])
-        return self.action_to_number(action)
+                return self.expected_discards[player]
+            # else:
+            #     print("I made an unexpected move myself",action,cardname, player, self.given_clues[0])
+        return action
 
     def think_at_turn_start(self, me, r):
         """ self (players[me]) thinks at the start of the turn. They interpret the last action,
@@ -208,38 +226,51 @@ class HatPlayer(AIPlayer):
         rawaction = r.playHistory[-1]
         action, card = self.interpret_external_action(rawaction)
         cardname = card['name'] if action[0] != 'hint' else ""
+        for d in self.given_clues[1:]:
+            d['plays'][player] = (action, card)
         if me == player:
             if action[0] != 'play': return
-            for d in self.given_clues:
-                d['plays'][player] = (action, card)
+            if card['misplayed'] and r.verbose:
+                print("I misplayed!",self.given_clues[0])
+            self.player_to_card_current[player] = action[1], cardname
             self.resolve_given_clues(me, r)
             assert not self.given_clues
             return
         # If I'm clued, update my value
         if self.given_clues:
             # print("debug",me,"and",self.given_clues[0])
-            # print(me,"thinks this was action",self.real_action_value(action, cardname, player),"- unmodified:",self.action_to_number(action))
-            self.given_clues[0]['value'] -= self.real_action_value(action, cardname, player)
+            # print(me,"thinks this was action",self.clued_action(action, cardname, player),"- unmodified:",self.action_to_number(action))
+            #self.player_to_card[i]
+            real_action = self.clued_action(action, cardname, player)
+            if real_action[0] == 'play':
+                assert real_action == action
+                self.player_to_card_current[player] = action[1], cardname
+            self.given_clues[0]['value'] -= self.action_to_number(real_action)
             self.given_clues[0]['value'] = self.given_clues[0]['value'] % 9
-        # If I predicted this play, remove the prediction
-        if player in self.player_to_card:
-            # print(me,"predicted that player",player,"would play position",self.player_to_card[player],"and position",action[1],"was played")
-            if action[0] == 'play' and self.player_to_card[player] == action[1]:
-                self.player_to_card.pop(player)
-                self.card_to_player.pop(cardname)
-            else:
-                print(me, "thinks that player", player, "didn't play the right card. He did",action,"cardname",cardname,"dics",
-                    self.player_to_card,self.card_to_player,"current hand",[card['name'] for card in r.h[player].cards])
-                if not (action[0] == 'discard' and self.player_to_card[player] == action[1]):
-                    index = self.player_to_card[player] - (0 if action[0] == 'hint' or action[1] > self.player_to_card[player] else 1)
-                    cardname = r.h[player].cards[index]['name']
+        else:
+            if r.verbose:
+                diff = (player - me - 1) % r.nPlayers
+                if diff < len(self.next_player_actions):
+                    exp_action = self.next_player_actions[diff]
+                    if not (exp_action == action or (exp_action[0] == 'discard' and action[0] == 'hint')):
+                        print("Player",me,"expected that player",player,"did",exp_action,"instead of",action,self.next_player_actions)
 
+            # If I predicted this play and I'm not currently clued, remove the prediction
+            if player in self.player_to_card:
+                # print(me,"predicted that player",player,"would play position",self.player_to_card[player],"and position",action[1],"was played")
+                if action[0] == 'play' and self.player_to_card[player][0] == action[1]:
+                    self.player_to_card.pop(player)
+                    self.card_to_player.pop(cardname)
+                else:
+                    # print(me, "thinks that player", player, "didn't play the right card. He did",action,"cardname",cardname,"dics",
+                    #     self.player_to_card,self.card_to_player,"current hand",[card['name'] for card in r.h[player].cards])
+                    cardname = self.player_to_card[player][1]
+                    # if not (action[0] == 'discard' and self.player_to_card[player][0] == action[1]):
+                    #     index = self.player_to_card[player] - (0 if action[0] == 'hint' or action[1] > self.player_to_card[player] else 1)
+                    #     cardname = r.h[player].cards[index]['name']
+                    self.player_to_card.pop(player)
+                    self.card_to_player.pop(cardname)
 
-                self.player_to_card.pop(player)
-                self.card_to_player.pop(cardname)
-
-        for d in self.given_clues[1:]:
-            d['plays'][player] = (action, card)
         if action[0] != 'hint':
             return
         target, value = rawaction[1]
@@ -266,8 +297,8 @@ class HatPlayer(AIPlayer):
         # test whether the card in to make `cardname` playable is played on time
         if prev_cardname(cardname) in dic:
             return self.is_between(dic[prev_cardname(cardname)], cluer, player)
-        else:
-            print("The card",cardname,"will not become playable")
+        # print("The card",cardname,"will not become playable")
+        return False
 
     def standard_action(self, cluer, player, dont_play, progress, card_to_player, player_to_card, r):
         """Returns which action should be taken by `player`. Uses the internal encoding of actions:
@@ -285,7 +316,7 @@ class HatPlayer(AIPlayer):
         assert self != r.PlayerRecord[player]
         # if the player is already playing, don't change the clue
         if player in player_to_card:
-            return "play", player_to_card[player]
+            return "play", player_to_card[player][0]
         cards = r.h[player].cards
         # Do I want to play?
         playableCards = [card for card in cards
@@ -297,65 +328,94 @@ class HatPlayer(AIPlayer):
         # I cannot play
         return self.standard_nonplay(cards, player, progress, r)
 
-    # def modified_action(self, cluer, player, dont_play, progress, card_to_player, player_to_card, r):
-    #     """Modified play for the first player the cluegiver clues. This play can
-    #     be smarter than standard_action"""
-    #     # note: in this command: self.futuredecksize and self.futureprogress and self.futureplays and self.futurediscards only counts the turns before `player`
-    #     # self.cards_played and self.cards_discarded only counts the cards drawn by the current clue (so after `player`)
-    #     # self.min_futurehints, self.futurehints and self.max_futurehints include all turns before and after `player`
+    def prepare_modified_action(self, r):
+        """Set variables needed for modified_action"""
+        self.other_actions = self.actions_before_modified + self.next_player_actions
+        self.futureplays = len([action for action in self.other_actions if action[0] == 'play'])
+        self.futurediscards = len([action for action in self.other_actions if action[0] == 'discard'])
+        self.futuredecksize = len(r.deck) - self.futureplays - self.futurediscards
+        self.endgame = len(r.deck) < count_unplayed_playable_cards(r, r.progress)
+        self.modified_hints = r.hints - 1
+        i = next(r.whoseTurn, r)
+        for _, pos in self.actions_before_modified:
+            if r.h[i].cards[pos]['name'][0] == '5':
+                self.modified_hints += 1
+            i = next(i, r)
+        self.min_futurehints = self.modified_hints
+        self.futurehints = self.modified_hints
+        assert i == self.modified_player
+        i = next(i, r)
+        for atype, pos in self.next_player_actions:
+            if atype == 'hint':
+                self.futurehints -= 1
+                self.min_futurehints = min(self.min_futurehints, self.futurehints)
+            elif atype == 'discard':
+                self.futurehints += 1
+            elif r.h[i].cards[pos]['name'][0] == '5':
+                self.futurehints += 1
+            i = next(i, r)
+        #print("Now at",r.hints,"clues, modified has",self.modified_hints,"minimal",self.min_futurehints,"end",self.futurehints,self.endgame)
 
-    #     # this is never called on a player's own hand
-    #     assert self != r.PlayerRecord[player]
-    #     assert self == r.PlayerRecord[cluer]
-    #     cards = r.h[player].cards
-    #     x = self.standard_action(cluer, player, dont_play, progress, card_to_player, player_to_card, r)
-    #     if not MODIFIEDACTION:
-    #         return x
-    #     # If you were instructed to play, and you can play a 5 which will help
-    #     # a future person to clue, do that.
-    #     if x[0] == 'play':
-    #         if self.min_futurehints <= 0 and cards[x[1]]['name'][0] != '5':
-    #             playablefives = [card for card in get_plays(cards, progress)
-    #                     if card['name'][0] == '5']
-    #             if playablefives:
-    #                 if r.verbose:
-    #                     print('play a 5 instead')
-    #                 return 'play', cards.index(playablefives[0])
-    #         return x
-    #     # If you are at 8 hints, hint
-    #     # if self.modified_hints >= 8: # todo
-    #     #     return 'hint', 0
-    #     # If we are not in the endgame yet and you can discard, just do it
-    #     if x[0] == 'discard' and self.futuredecksize >= count_unplayed_playable_cards(r, self.futureprogress):
-    #         return x
-    #     if (not self.cards_played) and (not self.futureplays) and r.verbose:
-    #         print('nobody can play!')
+    def modified_action(self, cluer, player, dont_play, progress, card_to_player, player_to_card, r):
+        """Modified play for the first player the cluegiver clues. This play can
+        be smarter than standard_action"""
+        # note: in this command: self.futuredecksize and self.futureprogress and self.futureplays and self.futurediscards only counts the turns before `player`
+        # self.cards_played and self.cards_discarded only counts the cards drawn by the current clue (so after `player`)
+        # self.min_futurehints, self.futurehints and self.max_futurehints include all turns before and after `player`
 
-    #     # Sometimes you want to discard. This happens if either
-    #     # - someone is instructed to hint without clues
-    #     # - everyone else will hint
-    #     # - everyone else will hint or discard, and it is not the endgame
-    #     if self.min_futurehints <= 0 or self.futurehints <= 1 or \
-    #     ((not self.cards_played) and (not self.futureplays) and (not self.cards_discarded) and (not self.futurediscards)) or\
-    #     ((not self.cards_played) and (not self.futureplays) and self.futuredecksize >= count_unplayed_playable_cards(r, self.futureprogress)):
-    #         if self.futurehints <= 1 and r.verbose:
-    #             print("keeping a clue for the next cluer, otherwise they would be at", self.futurehints - 1, "( now at", r.hints, ")")
-    #         if self.min_futurehints <= 0 and r.verbose:
-    #             print("discarding to make sure everyone can clue, otherwise they would be at", self.min_futurehints - 1, "( now at", r.hints, ")")
-    #         y = self.easy_discards(cards, progress, r)
-    #         if y[0] == 'discard':
-    #             if r.verbose:
-    #                 print('discard instead')
-    #             return y
-    #         y = self.hard_discards(cards, dont_play, progress, r)
-    #         if y[0] == 'discard':
-    #             if r.verbose:
-    #                 print('discard a useful card instead')
-    #             return y
-    #         if r.verbose:
-    #             print('all cards are critical!', progress)
-    #     # when we reach this point, we either have no easy discards or we are in the endgame, and there is no emergency, so we stall
-    #     return 'hint', 0
+        # this is never called on a player's own hand
+        assert self != r.PlayerRecord[player]
+        assert self == r.PlayerRecord[cluer]
+        cards = r.h[player].cards
+        x = self.standard_action(cluer, player, dont_play, progress, card_to_player, player_to_card, r)
+        if not MODIFIEDACTION:
+            return x
+        # If you were instructed to play, and you can play a 5 which will help
+        # a future person to clue, do that.
+        if x[0] == 'play':
+            if self.min_futurehints <= 0 and cards[x[1]]['name'][0] != '5':
+                playablefives = [card for card in get_plays(cards, progress)
+                        if card['name'][0] == '5']
+                if playablefives:
+                    if r.verbose:
+                        print('play a 5 instead')
+                    return 'play', cards.index(playablefives[0])
+            return x
+        # If you are at 8 hints, hint
+        if self.modified_hints >= 8:
+            return 'hint', 0
+        # Probably hint if everyone else is playing
+        if self.futureplays == 3 and self.modified_hints + len(self.actions_before_modified) >= 5:
+            return 'hint', 0
+        #todo: test if modified_player can get a new card to play
+        # If you can discard and we are not in the endgame yet or nobody can play, just discard
+        if x[0] == 'discard' and ((not self.endgame) or not self.futureplays):
+            return x
+
+        # Sometimes you want to discard. This happens if either
+        # - someone is instructed to hint without clues
+        # - nobody can play, and few people can discardeveryone else will hint
+        # - everyone else will hint or discard, and it is not the endgame
+        if self.min_futurehints <= 0 or self.futurehints <= 1 or\
+            (not self.futureplays and not self.endgame):
+            # if self.futurehints <= 1 and r.verbose:
+            #     print("keeping a clue for the next cluer, otherwise they would be at", self.futurehints - 1, "( now at", r.hints, ")")
+            # if self.min_futurehints <= 0 and r.verbose:
+            #     print("discarding to make sure everyone can clue, otherwise they would be at", self.min_futurehints - 1, "( now at", r.hints, ")")
+            y = self.easy_discards(cards, progress, r)
+            if y[0] == 'discard':
+                if r.verbose:
+                    print('discard instead')
+                return y
+            y = self.hard_discards(cards, dont_play, progress, r)
+            if y[0] == 'discard':
+                if r.verbose:
+                    print('discard a useful card instead')
+                return y
+            if r.verbose:
+                print('all cards are critical!', progress)
+        # when we reach this point, we either have no easy discards or we are in the endgame, and there is no emergency, so we stall
+        return 'hint', 0
 
 
     def easy_discards(self, cards, progress, r):
@@ -487,10 +547,8 @@ class HatPlayer(AIPlayer):
         of that card in the hand"""
         me = r.whoseTurn
         cards = r.h[me].cards
-        # if myaction[0] == 'discard' and r.hints == 8:
-            # todo: change the game code so that it rejects this
-            # print("Cheating! Discarding with 8 available hints")
-            # print("Debug info: me:", me, "given clue: ", self.given_clues[0])
+        if myaction[0] == 'discard' and r.hints == 8:
+            print("Cheating! Discarding with 8 available hints")
         if myaction[0] == 'discard' and 0 < len(r.deck) < \
             count_unplayed_playable_cards(r, r.progress) and r.verbose:
             print("Discarding in endgame")
@@ -532,25 +590,26 @@ class HatPlayer(AIPlayer):
                 return self.execute_action(myaction, r)
             if myaction[0] == 'discard':
                 # todo: decide if I want to hint instead
-                return self.execute_action(myaction, r)
+                # return self.execute_action(myaction, r)
                 #discard in endgame or if I'm the first to receive the clue
-                # if r.hints == 0 or (self.modified_player == me and MODIFIEDACTION):
-                #     if r.hints != 8:
-                #         return self.execute_action(myaction, r)
-                #     elif r.verbose:
-                #         print("I have to hint at 8 clues, this will screw up the next player's action.")
-                # #todo: also discard when you steal the last clue from someone who has to clue
-                # #clue if I can get tempo on a unclued card or if at 8 hints
-                # if r.hints != 8 and not(all(map(lambda a:a[0] == 'play', self.next_player_actions)) and\
-                # get_plays(r.h[(self.last_clued_any_clue + 1) % n].cards, progress)): #todo: this must be checked after current clued cards are played
-                #     #if not in endgame, or with at most 1 clue, discard
-                #     if len(r.deck) >= count_unplayed_playable_cards(r, r.progress):
-                #         return self.execute_action(myaction, r)
-                #     if r.hints <= 1:
-                #         return self.execute_action(myaction, r)
+                if r.hints == 0 or (self.modified_player == me and MODIFIEDACTION):
+                    if r.hints != 8:
+                        return self.execute_action(myaction, r)
+                    elif r.verbose:
+                        print("I have to hint at 8 clues as modified player, this will screw up the next player's action.")
+                #todo: also discard when you steal the last clue from someone who has to clue
+                #clue if I can get tempo on a unclued card or if at 8 hints
+                if r.hints != 8 and not(all(map(lambda a:a[0] == 'play', self.next_player_actions)) and\
+                get_plays(r.h[self.given_clues[0]['cluer']].cards, self.futureprogress)): # todo: is futureprogress correct here?
+                    #if not in endgame, or with at most 1 clue, discard
+                    if len(r.deck) >= count_unplayed_playable_cards(r, r.progress):
+                        return self.execute_action(myaction, r)
+                    if r.hints <= 1: # todo: check if there will be a hint available because someone played a 5
+                        return self.execute_action(myaction, r)
         if not r.hints: # I cannot hint without clues
             if r.verbose:
                 print("Cannot clue, because there are no available hints")
+            self.next_player_actions = []
             x = 3
             if self.safe_discard is not None and self.safe_discard in r.h[me].cards:
                 x = r.h[me].cards.index(self.safe_discard)
@@ -559,19 +618,20 @@ class HatPlayer(AIPlayer):
             #todo: maybe discard the card so that the next player does something non-terrible
             return self.execute_action(('discard', x), r)
         # I'm am considering whether to give a clue
-        # I have already executed resolve_next_player_actions, but now I probably need more details about number of clues left and so on
+        # todo: get more info for modified_play
         # print("I'm going to clue with progress",self.futureprogress,"dics:",self.player_to_card,self.card_to_player)
 
         # We first compute the value of all plays other than that of modified_player
         value = self.initialize_given_clue(me, me, r)
 
-        x = self.standard_action(me, self.modified_player, self.will_be_played, self.futureprogress, self.card_to_player, self.player_to_card, r)
+        # x = self.standard_action(me, self.modified_player, self.will_be_played, self.futureprogress, self.card_to_player, self.player_to_card, r)
         # print("modified action for player",self.modified_player,"is",x)
-        # todo: do stuff to find best modified_action
-#        x = self.modified_action(me, self.modified_player, self.will_be_played, self.futureprogress, self.card_to_player, self.player_to_card, r)
+        self.prepare_modified_action(r)
+        x = self.modified_action(me, self.modified_player, self.will_be_played, self.futureprogress, self.card_to_player, self.player_to_card, r)
         self.actions_before_modified.append(x)
         self.next_player_actions = self.actions_before_modified + self.next_player_actions
-        self.resolve_next_player_actions(me, r)
+        self.given_clues = []
+        self.finalize_given_clue(me, r)
         # print("Now future progress is",self.futureprogress)
         value = (value + self.action_to_number(x)) % 9
         clue = self.number_to_clue(value, me, r)

--- a/players/heuristics_player.py
+++ b/players/heuristics_player.py
@@ -2,7 +2,7 @@
   This bot looks at the probability that a given card is playable
   and plays it if above a threshold value that varies based on
   number of bombs played
-  Indirect hints have no multiplier on their 
+  Indirect hints have no multiplier on their
 
 """
 
@@ -75,10 +75,10 @@ class HeuristicsUtils(object):
 
     def scale_probability(self, probability, scale):
         return probability ** (1.0 / scale)
-        
+
     def get_probability_discardable(self, card):
 
-        useful_cardnames = get_all_useful_cardnames(self.player, self.r)
+        useful_cardnames = get_all_useful_cardnames(self.r)
 
         # If we know for sure what the card is
         if (card['known']):
@@ -90,7 +90,7 @@ class HeuristicsUtils(object):
         for card_name, probability in probability_of_cards.items():
             if card_name in useful_cardnames:
                 overallProbability += probability
-        
+
         print(overallProbability)
 
     def get_probability_playable(self, card, location):
@@ -153,7 +153,7 @@ class HeuristicsTracking(object):
         self.on = on
         self.playable_cards = []
         self.unplayable_cards = []
-        
+
     def record_playable(self, card, probability, progress):
         if not self.on:
             return


### PR DESCRIPTION
Over the last month, I greatly improved the hat player. It now performs 10pp better than before. Its current winrates are (on 10000 games starting with seed 0)
```
Players | % (no variant) | % (purple) | % (rainbow)
--------+----------------+------------+-------------
   4    |      94.2      |    94.4    |    94.2
   5    |      91.2      |    95.7    |    95.7
```
The main improvements of `hat_player` are described in `doc_hat_player.md`

I also added some features:
* I added an `-o` flag which outputs a log of the game in JSON format. This output can be read by the website hanabi.live so that you can watch a replay of the game with a nice user interface.
* I added slightly more information to the `Card` class. Namely 1: it's original position in the deck, 2: after the card was discarded/played, the position in the hand it was discarded/played from and 3: whether it caused a misplay after being played.
* I improved `cheating_player` a bit.